### PR TITLE
feat(release): v1.2.1 — sharpen scope/maintenance posture in docs

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -16,9 +16,11 @@ However, I intend to keep the AWS SDK for Rust and other dependencies up to date
 
 ## Before opening an issue
 
-Please read the [Scope and Non-Goals](https://github.com/nidor1998/s7cmd/blob/main/README.md#scope) section of the README first. **Issues asking about behavior already documented in the README — including anything listed under Non-Goals — will be closed without further discussion.** This is not a rejection of your input; it is the project's documented scope.
+Please read the [Scope and Non-Goals](https://github.com/nidor1998/s7cmd/blob/main/README.md#scope) and [Maintenance Model](https://github.com/nidor1998/s7cmd/blob/main/README.md#maintenance-model) sections of the README first. **Issues asking about behavior already documented in the README — including anything listed under Non-Goals — will be closed without further discussion.** This is not a rejection of your input; it is the project's documented scope and maintenance posture.
 
-This template is for bug reports only. **Feature requests filed here will be closed unconditionally.**
+This template is for bug reports only. **Anything that is not a clear, reproducible bug in s7cmd itself — including feature requests, questions, usage help, configuration help, and discussion threads — will be closed unconditionally.**
+
+**This project is intended for users who can self-resolve usage questions, configuration issues, and environment-specific problems. Only clear, reproducible bugs in s7cmd itself are accepted — nothing else.** No support, no questions, no feature requests, no usage help.
 
 ## Issue lifecycle
 
@@ -51,7 +53,8 @@ When verifying the reproducibility of a bug report, any report lacking informati
 
 - OS: [e.g. macOS 14.5, Ubuntu 24.04, Windows 11]
 - s7cmd version: [output of `s7cmd --version`] — **only the latest release is supported**. Issues filed against any other version will be closed automatically; please reproduce on the latest version before filing.
-- Storage: [e.g. Amazon S3, MinIO, Cloudflare R2, Ceph RGW] — only Amazon S3 is supported. Issues against S3-compatible services generally cannot be supported and may be closed.
+- Storage: [e.g., Amazon S3, MinIO, Cloudflare R2, Ceph RGW] — only Amazon S3 is supported. Issues regarding S3-compatible services will be closed automatically, unconditionally, and without exception.
+- Region: [e.g., us-east-1, ap-northeast-1]
 
 ## Additional context
 

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -49,7 +49,7 @@ A clear and concise description of what you expected to happen.
 
 ## Environment
 
-When verifying the reproducibility of a bug report, any report lacking information on the OS, s7cmd version, and Storage will be closed without exception.
+When verifying the reproducibility of a bug report, any report lacking information on the OS, s7cmd version, Storage, and Region will be closed without exception.
 
 - OS: [e.g. macOS 14.5, Ubuntu 24.04, Windows 11]
 - s7cmd version: [output of `s7cmd --version`] — **only the latest release is supported**. Issues filed against any other version will be closed automatically; please reproduce on the latest version before filing.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,36 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.2.1] - 2026-05-09
+
+### Changed
+
+- Documentation: clarified that **Amazon S3 is the only supported
+  platform**. S3-compatible storage (MinIO, Cloudflare R2,
+  Backblaze B2, Wasabi, Ceph RGW, DigitalOcean Spaces, IBM COS,
+  and similar) is provided strictly **as-is**, with **absolutely
+  no support or assistance**. Bug reports, questions, and
+  assistance requests regarding S3-compatible storage will not be
+  addressed.
+- Bug report template (`.github/ISSUE_TEMPLATE/bug_report.md`):
+  tightened the Storage line to state that issues regarding
+  S3-compatible services will be closed automatically,
+  unconditionally, and without exception; added a Region field;
+  added a notice that only clear, reproducible bugs in s7cmd
+  itself are accepted (no support, questions, feature requests,
+  or usage help).
+
+### Underlying libraries
+
+Pinned versions are unchanged from 1.2.0:
+
+```toml
+s3sync     = "=1.58.6"
+s3util-rs  = "=1.4.0"
+s3rm-rs    = "=1.3.6"
+s3ls-rs    = "=1.0.1"
+```
+
 ## [1.2.0] - 2026-05-07
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3054,7 +3054,7 @@ dependencies = [
 
 [[package]]
 name = "s7cmd"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "s7cmd"
-version = "1.2.0"
+version = "1.2.1"
 edition = "2024"
 rust-version = "1.91.1"
 license = "Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -56,21 +56,21 @@ replication, transfer acceleration, request payment). For any S3 use
 case outside that scope, use a more comprehensive tool such as the
 [AWS CLI](https://aws.amazon.com/cli/) (`aws s3api`).
 
-s7cmd targets **Amazon S3** as its primary supported platform.
+s7cmd targets **Amazon S3** as its only supported platform.
 S3-compatible storage (MinIO, Cloudflare R2, Backblaze B2, Wasabi,
-Ceph RGW, DigitalOcean Spaces, IBM COS, and similar) is supported
-on a **best-effort basis only** — such services may work via
-`--endpoint-url` (and `--source-force-path-style` /
-`--target-force-path-style` when path-style addressing is required),
-but they are not part of the official test matrix
-and behavior may change between releases. This is a structural
-consequence of building on `aws-sdk-rust`, which is generated from
-AWS service models and assumes Amazon S3 semantics (checksum
-headers, endpoint resolution, signing variants, response schemas);
-features that depend on AWS-specific semantics, such as CRC64NVME
-checksums or newer S3 API additions, may not work against
-non-AWS endpoints. Bug reports against S3-compatible storage will
-be triaged but not prioritized, and fixes are not guaranteed.
+Ceph RGW, DigitalOcean Spaces, IBM COS, and similar) is provided
+strictly **as-is**, with **absolutely no support or assistance** —
+such services may work via `--endpoint-url` (and
+`--source-force-path-style` / `--target-force-path-style` when
+path-style addressing is required), but they are not part of the
+official test matrix and behavior may change between releases. This
+is a structural consequence of building on `aws-sdk-rust`, which is
+generated from AWS service models and assumes Amazon S3 semantics
+(checksum headers, endpoint resolution, signing variants, response
+schemas); features that depend on AWS-specific semantics, such as
+CRC64NVME checksums or newer S3 API additions, may not work against
+non-AWS endpoints. Bug reports, questions, and assistance requests
+regarding S3-compatible storage will not be addressed.
 
 s7cmd is **not** intended to be a drop-in replacement for, or
 behaviorally compatible with, any other S3 client — including the

--- a/README.md
+++ b/README.md
@@ -91,13 +91,13 @@ The following are explicitly out of scope and will not be added,
 regardless of demand:
 
 - Support, testing, or guaranteed compatibility for any
-  storage service other than Amazon S3. S3-compatible storage may
-  work on a best-effort basis as described in the Scope section
-  above, but adding dedicated code paths, provider-specific
-  workarounds, or backends for services such as MinIO, Cloudflare
-  R2, Backblaze B2, Wasabi, Ceph RGW, DigitalOcean Spaces, IBM COS,
-  Tencent COS, Alibaba OSS, Azure Blob Storage, or Google Cloud
-  Storage is out of scope.
+  storage service other than Amazon S3. S3-compatible storage is
+  provided strictly as-is, with no support or assistance, as
+  described in the Scope section above; adding dedicated code
+  paths, provider-specific workarounds, or backends for services
+  such as MinIO, Cloudflare R2, Backblaze B2, Wasabi, Ceph RGW,
+  DigitalOcean Spaces, IBM COS, Tencent COS, Alibaba OSS, Azure
+  Blob Storage, or Google Cloud Storage is out of scope.
 - Feature parity with, or porting features from, other S3 clients.
   Feature requests of the form "tool X has feature Y, please add
   it to s7cmd" — including variants such as "feature Y would also


### PR DESCRIPTION
Bumps version to 1.2.1. Underlying library pins (s3sync, s3util-rs, s3rm-rs, s3ls-rs) are unchanged from 1.2.0; this is a docs-only release.

- README: Amazon S3 is now stated as the *only* supported platform; S3-compatible storage is provided strictly as-is with no support or assistance.
- Bug report template: broadened the closure rule (anything that is not a clear, reproducible bug — feature requests, questions, usage help, configuration help, discussion threads — closed unconditionally); tightened S3-compatible Storage line; added a Region field; added a Maintenance Model link to the README; added a notice that this project is for users who can self-resolve usage/configuration/environment issues.

## Contributing

- Bug reports are welcome, but responses are not guaranteed.
- Since this project is considered functionally complete, I will not accept any feature requests.
- If you find this project useful, feel free to fork and modify it as you wish.

🔒 I consider this project “complete” and will maintain it only minimally going forward.
However, I intend to keep the AWS SDK for Rust and other dependencies up to date monthly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes v1.2.1

* **Documentation**
  * Clarified that Amazon S3 is the only officially supported platform; S3-compatible storage is provided strictly as-is with no support.

* **Chores**
  * Updated issue template to enforce stricter criteria for bug reports, accepting only clear, reproducible s7cmd bugs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->