### PR TITLE
bump(version): update to 1.2.5 with dependency upgrades

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,31 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.3.0] - 2026-05-24
+
+Monthly update.
+
+### Added
+
+#### s3utils-rs
+- `rename` subcommand: atomically rename an object within the same S3 Express One Zone directory bucket using the RenameObject API. 
+Both source and target must be in the same bucket (name must end with --x-s3). Supports optional conditional checks.
+
+### Changed
+
+- aws-sdk-s3 `v1.131.0 -> v1.133.0`
+- Updated other dependencies
+
+
+### Underlying libraries
+
+```toml
+s3sync     = "=1.58.8"
+s3util-rs  = "=1.5.2"
+s3rm-rs    = "=1.3.7"
+s3ls-rs    = "=1.0.2"
+```
+
 ## [1.2.4] - 2026-05-17
 
 ### Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2977,9 +2977,9 @@ dependencies = [
 
 [[package]]
 name = "s3util-rs"
-version = "1.5.0"
+version = "1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "418df43028d3103b6a2f3054b9ceacf514dcd2f58d6de8002cbb6384bd4261f5"
+checksum = "5bbf96e11161442c115866348bccc100c69171c2325c4ea84abb2a126a7f517e"
 dependencies = [
  "anyhow",
  "async-channel",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -157,9 +157,9 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "aws-config"
-version = "1.8.16"
+version = "1.8.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50f156acdd2cf55f5aa53ee416c4ac851cf1222694506c0b1f78c85695e9ca9d"
+checksum = "517aa062d8bd9015ee23d6daa5e1c1372328412fdae4e6c4c1be9b69c6ad37a2"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -171,6 +171,7 @@ dependencies = [
  "aws-smithy-json",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
+ "aws-smithy-schema",
  "aws-smithy-types",
  "aws-types",
  "bytes",
@@ -284,9 +285,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-sso"
-version = "1.98.0"
+version = "1.99.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d69c77aafa20460c68b6b3213c84f6423b6e76dbf89accd3e1789a686ffd9489"
+checksum = "9f4055e6099b2ec264abdc0d9bbfffce306c1601809275c861594779a0b04b45"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -308,9 +309,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-ssooidc"
-version = "1.100.0"
+version = "1.101.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c7e7b09346d5ca22a2a08267555843a6a0127fb20d8964cb6ecfb8fdb190225"
+checksum = "02f009ba0284c5d696425fd7b4dcc5b189f5726f4041b7a5794daecb3a68d598"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -332,9 +333,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-sts"
-version = "1.103.0"
+version = "1.104.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2249b81a2e73a8027c41c378463a81ec39b8510f184f2caab87de912af0f49b"
+checksum = "6aa6622798e19e6a76b690562085dd4771c736cd48343464a53ab4ae2f2c9f84"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -869,9 +870,9 @@ dependencies = [
 
 [[package]]
 name = "clap_complete"
-version = "4.6.3"
+version = "4.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "660c0520455b1013b9bcb0393d5f643d7e4454fb69c915b8d6d2aa0e9a45acc3"
+checksum = "e0a7a9bfdb35811f9e59832f0f05975114d2251b415fb534108e6f34060fd772"
 dependencies = [
  "clap",
 ]
@@ -1281,13 +1282,12 @@ dependencies = [
 
 [[package]]
 name = "filetime"
-version = "0.2.27"
+version = "0.2.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f98844151eee8917efc50bd9e8318cb963ae8b297431495d3f758616ea5c57db"
+checksum = "5c287a33c7f0a620c38e641e7f60827713987b3c0f26e8ddc9462cc69cf75759"
 dependencies = [
  "cfg-if",
  "libc",
- "libredox",
 ]
 
 [[package]]
@@ -2029,18 +2029,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "libredox"
-version = "0.1.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
-dependencies = [
- "bitflags",
- "libc",
- "plain",
- "redox_syscall 0.7.5",
-]
-
-[[package]]
 name = "libz-sys"
 version = "1.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2326,7 +2314,7 @@ checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall 0.5.18",
+ "redox_syscall",
  "smallvec",
  "windows-link",
 ]
@@ -2348,18 +2336,18 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "pin-project"
-version = "1.1.12"
+version = "1.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbf0d9e68100b3a7989b4901972f265cd542e560a3a8a724e1e20322f4d06ce9"
+checksum = "2466b2336ed02bcdca6b294417127b90ec92038d1d5c4fbeac971a922e0e0924"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.1.12"
+version = "1.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a990e22f43e84855daf260dded30524ef4a9021cc7541c26540500a50b624389"
+checksum = "c96395f0a926bc13b1c17622aaddda1ecb55d49c8f1bf9777e4d877800a43f8b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2393,12 +2381,6 @@ name = "pkg-config"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
-
-[[package]]
-name = "plain"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "portable-atomic"
@@ -2614,15 +2596,6 @@ name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
-dependencies = [
- "bitflags",
-]
-
-[[package]]
-name = "redox_syscall"
-version = "0.7.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4666a1a60d8412eab19d94f6d13dcc9cea0a5ef4fdf6a5db306537413c661b1b"
 dependencies = [
  "bitflags",
 ]
@@ -3004,9 +2977,9 @@ dependencies = [
 
 [[package]]
 name = "s3util-rs"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "233a23161fb2c0a430979baff8ba3c0e6984b8ddd6b0e6656846332277e0a6ae"
+checksum = "418df43028d3103b6a2f3054b9ceacf514dcd2f58d6de8002cbb6384bd4261f5"
 dependencies = [
  "anyhow",
  "async-channel",
@@ -3219,9 +3192,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.149"
+version = "1.0.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
 dependencies = [
  "itoa",
  "memchr",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -199,9 +199,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.16.3"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ec6fb3fe69024a75fa7e1bfb48aa6cf59706a101658ea01bfd33b2b248a038f"
+checksum = "5ec2f1fc3ec205783a5da9a7e6c1509cc69dedf09a1949e412c1e18469326d00"
 dependencies = [
  "aws-lc-sys",
  "zeroize",
@@ -209,9 +209,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.40.0"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f50037ee5e1e41e7b8f9d161680a725bd1626cb6f8c7e901f91f942850852fe7"
+checksum = "1a2f9779ce85b93ab6170dd940ad0169b5766ff848247aff13bb788b832fe3f4"
 dependencies = [
  "cc",
  "cmake",
@@ -221,9 +221,9 @@ dependencies = [
 
 [[package]]
 name = "aws-runtime"
-version = "1.7.3"
+version = "1.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dcd93c82209ac7413532388067dce79be5a8780c1786e5fae3df22e4dee2864"
+checksum = "77ed8e8c52d2dc2390ad9f15647fe663f71e9780b4262c190fbb823a32721566"
 dependencies = [
  "aws-credential-types",
  "aws-sigv4",
@@ -249,9 +249,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-s3"
-version = "1.131.0"
+version = "1.133.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe1b8c5282bf859170836045296b3cd710b7573aceb909498366bb508a41058e"
+checksum = "237aba2985e3c0a83e199cc7aa9a64a16c599875bc98170f00932f6199f19922"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -357,9 +357,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sigv4"
-version = "1.4.3"
+version = "1.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68dc0b907359b120170613b5c09ccc61304eac3998ff6274b97d93ee6490115a"
+checksum = "b7083fb918b38474ac65ffbf8a69fc8792d36879f4ac5f1667b43aec61efe9a5"
 dependencies = [
  "aws-credential-types",
  "aws-smithy-eventstream",
@@ -367,7 +367,7 @@ dependencies = [
  "aws-smithy-runtime-api",
  "aws-smithy-types",
  "bytes",
- "crypto-bigint 0.5.5",
+ "crypto-bigint",
  "form_urlencoded",
  "hex",
  "hmac 0.13.0",
@@ -375,7 +375,6 @@ dependencies = [
  "http 1.4.0",
  "p256",
  "percent-encoding",
- "ring",
  "sha2 0.11.0",
  "subtle",
  "time",
@@ -396,9 +395,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-checksums"
-version = "0.64.7"
+version = "0.64.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10efbbcec1e044b81600e2fc562a391951d291152d95b482d5b7e7132299d762"
+checksum = "e9e8e65f4f81fcccdeb6c3eca2af17ac21d421a1786a26a394aecf421d616d3a"
 dependencies = [
  "aws-smithy-http",
  "aws-smithy-types",
@@ -474,10 +473,12 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-json"
-version = "0.62.5"
+version = "0.62.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9648b0bb82a2eedd844052c6ad2a1a822d1f8e3adee5fbf668366717e428856a"
+checksum = "517089205f18ab4adc5a3e02888cb139bbbbb2e168eac9f396216925d1fbeaf5"
 dependencies = [
+ "aws-smithy-runtime-api",
+ "aws-smithy-schema",
  "aws-smithy-types",
 ]
 
@@ -502,15 +503,16 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-runtime"
-version = "1.11.1"
+version = "1.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0504b1ab12debb5959e5165ee5fe97dd387e7aa7ea6a477bfd7635dfe769a4f5"
+checksum = "b8e6f5caf6fea86f8c2206541ab5857cfcda9013426cdbe8fa0098b9e2d32182"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-http",
  "aws-smithy-http-client",
  "aws-smithy-observability",
  "aws-smithy-runtime-api",
+ "aws-smithy-schema",
  "aws-smithy-types",
  "bytes",
  "fastrand",
@@ -527,9 +529,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-runtime-api"
-version = "1.12.0"
+version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b71a13df6ada0aafbf21a73bdfcdf9324cfa9df77d96b8446045be3cde61b42e"
+checksum = "dc117c179ecf39a62a0a3f49f600e9ac26a7ad7dd172177999f83933af776c32"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-runtime-api-macros",
@@ -555,10 +557,21 @@ dependencies = [
 ]
 
 [[package]]
-name = "aws-smithy-types"
-version = "1.4.7"
+name = "aws-smithy-schema"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d73dbfbaa8e4bc57b9045137680b958d274823509a360abfd8e1d514d40c95c"
+checksum = "7442cb268338f0eb8278140a107c046756aa01093d8ef5e99628d34ae09c94f5"
+dependencies = [
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "http 1.4.0",
+]
+
+[[package]]
+name = "aws-smithy-types"
+version = "1.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "056b66dbce2f81cc0c1e2b05bb402eb58f8a3530479d650efadd5bbae9a4050b"
 dependencies = [
  "base64-simd",
  "bytes",
@@ -601,13 +614,14 @@ dependencies = [
 
 [[package]]
 name = "aws-types"
-version = "1.3.15"
+version = "1.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f4bbcaa9304ea40902d3d5f42a0428d1bd895a2b0f6999436fb279ffddc58ac"
+checksum = "d16bf10b03a3c01e6b3b7d47cd964e873ffe9e7d4e80fad16bd4c077cb068531"
 dependencies = [
  "aws-credential-types",
  "aws-smithy-async",
  "aws-smithy-runtime-api",
+ "aws-smithy-schema",
  "aws-smithy-types",
  "rustc_version",
  "tracing",
@@ -615,9 +629,9 @@ dependencies = [
 
 [[package]]
 name = "base16ct"
-version = "0.1.1"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "349a06037c7bf932dd7e7d1f653678b2038b9ad46a74102f1fc7bd7872678cce"
+checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
 
 [[package]]
 name = "base64"
@@ -785,14 +799,14 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.61"
+version = "1.2.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d16d90359e986641506914ba71350897565610e87ce0ad9e6f28569db3dd5c6d"
+checksum = "a1dce859f0832a7d088c4f1119888ab94ef4b5d6795d1ce05afb7fe159d79f98"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
  "libc",
- "shlex",
+ "shlex 1.3.0",
 ]
 
 [[package]]
@@ -990,29 +1004,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "crc"
-version = "3.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9710d3b3739c2e349eb44fe848ad0b7c8cb1e42bd87ee49371df2f7acaf3e675"
-dependencies = [
- "crc-catalog",
-]
-
-[[package]]
-name = "crc-catalog"
-version = "2.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "217698eaf96b4a3f0bc4f3662aaa55bdf913cd54d7204591faa790070c6d0853"
-
-[[package]]
 name = "crc-fast"
-version = "1.9.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fd92aca2c6001b1bf5ba0ff84ee74ec8501b52bbef0cac80bf25a6c1d87a83d"
+checksum = "e75b2483e97a5a7da73ac68a05b629f9c53cff58d8ed1c77866079e18b00dba5"
 dependencies = [
- "crc",
  "digest 0.10.7",
- "rustversion",
  "spin",
 ]
 
@@ -1061,24 +1058,14 @@ checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crypto-bigint"
-version = "0.4.9"
+version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef2b4b23cddf68b89b8f8069890e8c270d54e2d5fe1b143820234805e4cb17ef"
+checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
 dependencies = [
  "generic-array",
  "rand_core",
  "subtle",
  "zeroize",
-]
-
-[[package]]
-name = "crypto-bigint"
-version = "0.5.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
-dependencies = [
- "rand_core",
- "subtle",
 ]
 
 [[package]]
@@ -1111,11 +1098,12 @@ dependencies = [
 
 [[package]]
 name = "der"
-version = "0.6.1"
+version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1a467a65c5e759bce6e65eaf91cc29f466cdc57cb65777bd646872a8a1fd4de"
+checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
 dependencies = [
  "const-oid 0.9.6",
+ "pem-rfc7468",
  "zeroize",
 ]
 
@@ -1141,6 +1129,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer 0.10.4",
+ "const-oid 0.9.6",
  "crypto-common 0.1.7",
  "subtle",
 ]
@@ -1182,14 +1171,16 @@ checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "ecdsa"
-version = "0.14.8"
+version = "0.16.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "413301934810f597c1d19ca71c8710e99a3f1ba28a0d2ebc01551a2daeea3c5c"
+checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
 dependencies = [
  "der",
+ "digest 0.10.7",
  "elliptic-curve",
  "rfc6979",
  "signature",
+ "spki",
 ]
 
 [[package]]
@@ -1200,17 +1191,17 @@ checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "elliptic-curve"
-version = "0.12.3"
+version = "0.13.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7bb888ab5300a19b8e5bceef25ac745ad065f3c9f7efc6de1b91958110891d3"
+checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
 dependencies = [
  "base16ct",
- "crypto-bigint 0.4.9",
- "der",
+ "crypto-bigint",
  "digest 0.10.7",
  "ff",
  "generic-array",
  "group",
+ "pem-rfc7468",
  "pkcs8",
  "rand_core",
  "sec1",
@@ -1280,9 +1271,9 @@ checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "ff"
-version = "0.12.1"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d013fc25338cc558c5c2cfbad646908fb23591e2404481826742b651c9af7160"
+checksum = "c0b50bfb653653f9ca9095b427bed08ab8d75a137839d9ad64eb11810d5b6393"
 dependencies = [
  "rand_core",
  "subtle",
@@ -1459,6 +1450,7 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
+ "zeroize",
 ]
 
 [[package]]
@@ -1512,9 +1504,9 @@ dependencies = [
 
 [[package]]
 name = "group"
-version = "0.12.1"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dfbfb3a6cfbd390d5c9564ab283a0349b9b9fcd46a706c1eb10e0db70bfbac7"
+checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
 dependencies = [
  "ff",
  "rand_core",
@@ -1571,9 +1563,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.17.0"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "heck"
@@ -1668,9 +1660,9 @@ checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
 name = "hybrid-array"
-version = "0.4.11"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08d46837a0ed51fe95bd3b05de33cd64a1ee88fc797477ca48446872504507c5"
+checksum = "9155a582abd142abc056962c29e3ce5ff2ad5469f4246b537ed42c5deba857da"
 dependencies = [
  "typenum",
 ]
@@ -1875,7 +1867,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.17.0",
+ "hashbrown 0.17.1",
  "serde",
  "serde_core",
 ]
@@ -1970,9 +1962,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.97"
+version = "0.3.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1840c94c045fbcf8ba2812c95db44499f7c64910a912551aaaa541decebcacf"
+checksum = "67df7112613f8bfd9150013a0314e196f4800d3201ae742489d999db2f979f08"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -2300,12 +2292,13 @@ checksum = "1a80800c0488c3a21695ea981a54918fbb37abf04f4d0720c453632255e2ff0e"
 
 [[package]]
 name = "p256"
-version = "0.11.1"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51f44edd08f51e2ade572f141051021c5af22677e42b7dd28a88155151c33594"
+checksum = "c9863ad85fa8f4460f9c48cb909d38a0d689dba1f6f6988a5e3e0d31071bcd4b"
 dependencies = [
  "ecdsa",
  "elliptic-curve",
+ "primeorder",
  "sha2 0.10.9",
 ]
 
@@ -2336,6 +2329,15 @@ dependencies = [
  "redox_syscall 0.5.18",
  "smallvec",
  "windows-link",
+]
+
+[[package]]
+name = "pem-rfc7468"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
+dependencies = [
+ "base64ct",
 ]
 
 [[package]]
@@ -2378,9 +2380,9 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pkcs8"
-version = "0.9.0"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9eca2c590a5f85da82668fa685c09ce2888b9430e83299debf1f34b65fd4a4ba"
+checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
 dependencies = [
  "der",
  "spki",
@@ -2475,6 +2477,15 @@ checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "primeorder"
+version = "0.13.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6"
+dependencies = [
+ "elliptic-curve",
 ]
 
 [[package]]
@@ -2682,13 +2693,12 @@ dependencies = [
 
 [[package]]
 name = "rfc6979"
-version = "0.3.1"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7743f17af12fa0b03b803ba12cd6a8d9483a587e89c69445e3909655c0b9fabb"
+checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
 dependencies = [
- "crypto-bigint 0.4.9",
  "hmac 0.12.1",
- "zeroize",
+ "subtle",
 ]
 
 [[package]]
@@ -3054,7 +3064,7 @@ dependencies = [
 
 [[package]]
 name = "s7cmd"
-version = "1.2.4"
+version = "1.2.5"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -3081,7 +3091,7 @@ dependencies = [
  "s3util-rs",
  "serde_json",
  "shadow-rs",
- "shlex",
+ "shlex 2.0.1",
  "simple_moving_average",
  "tempfile",
  "tokio",
@@ -3136,9 +3146,9 @@ checksum = "1c107b6f4780854c8b126e228ea8869f4d7b71260f962fefb57b996b8959ba6b"
 
 [[package]]
 name = "sec1"
-version = "0.3.0"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3be24c1842290c45df0a7bf069e0c268a747ad05a192f2fd7dcfdbc1cba40928"
+checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
 dependencies = [
  "base16ct",
  "der",
@@ -3292,6 +3302,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "shlex"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
+
+[[package]]
 name = "signal-hook-registry"
 version = "1.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3303,9 +3319,9 @@ dependencies = [
 
 [[package]]
 name = "signature"
-version = "1.6.4"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74233d3b3b2f6d4b006dc19dee745e73e2a6bfb6f93607cd3b02bd5b00797d7c"
+checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
  "digest 0.10.7",
  "rand_core",
@@ -3362,9 +3378,9 @@ checksum = "d5fe4ccb98d9c292d56fec89a5e07da7fc4cf0dc11e156b41793132775d3e591"
 
 [[package]]
 name = "spki"
-version = "0.6.0"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67cf02bbac7a337dc36e4f5a693db6c21e7863f45070f7064577eb4367a3212b"
+checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
 dependencies = [
  "base64ct",
  "der",
@@ -3545,9 +3561,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.52.2"
+version = "1.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "110a78583f19d5cdb2c5ccf321d1290344e71313c6c37d43520d386027d18386"
+checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
 dependencies = [
  "bytes",
  "libc",
@@ -3771,18 +3787,31 @@ checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "ureq"
-version = "2.12.1"
+version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02d1a66277ed75f640d608235660df48c8e3c19f3b4edb6a263315626cc3c01d"
+checksum = "dea7109cdcd5864d4eeb1b58a1648dc9bf520360d7af16ec26d0a9354bafcfc0"
 dependencies = [
  "base64",
  "flate2",
  "log",
- "once_cell",
+ "percent-encoding",
  "rustls",
  "rustls-pki-types",
- "url",
- "webpki-roots 0.26.11",
+ "ureq-proto",
+ "utf8-zero",
+ "webpki-roots",
+]
+
+[[package]]
+name = "ureq-proto"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e994ba84b0bd1b1b0cf92878b7ef898a5c1760108fe7b6010327e274917a808c"
+dependencies = [
+ "base64",
+ "http 1.4.0",
+ "httparse",
+ "log",
 ]
 
 [[package]]
@@ -3808,6 +3837,12 @@ name = "utf8-width"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1292c0d970b54115d14f2492fe0170adf21d68a1de108eebc51c1df4f346a091"
+
+[[package]]
+name = "utf8-zero"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8c0a043c9540bae7c578c88f91dda8bd82e59ae27c21baca69c8b191aaf5a6e"
 
 [[package]]
 name = "utf8_iter"
@@ -3910,9 +3945,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.120"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df52b6d9b87e0c74c9edfa1eb2d9bf85e5d63515474513aa50fa181b3c4f5db1"
+checksum = "49ace1d07c165b0864824eee619580c4689389afa9dc9ed3a4c75040d82e6790"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -3923,9 +3958,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.120"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78b1041f495fb322e64aca85f5756b2172e35cd459376e67f2a6c9dffcedb103"
+checksum = "8e68e6f4afd367a562002c05637acb8578ff2dea1943df76afb9e83d177c8578"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -3933,9 +3968,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.120"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dcd0ff20416988a18ac686d4d4d0f6aae9ebf08a389ff5d29012b05af2a1b41"
+checksum = "d95a9ec35c64b2a7cb35d3fead40c4238d0940c86d107136999567a4703259f2"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -3946,9 +3981,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.120"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49757b3c82ebf16c57d69365a142940b384176c24df52a087fb748e2085359ea"
+checksum = "c4e0100b01e9f0d03189a92b96772a1fb998639d981193d7dbab487302513441"
 dependencies = [
  "unicode-ident",
 ]
@@ -3995,15 +4030,6 @@ checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
-]
-
-[[package]]
-name = "webpki-roots"
-version = "0.26.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
-dependencies = [
- "webpki-roots 1.0.7",
 ]
 
 [[package]]
@@ -4343,9 +4369,9 @@ dependencies = [
 
 [[package]]
 name = "zerofrom"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69faa1f2a1ea75661980b013019ed6687ed0e83d069bc1114e2cc74c6c04c4df"
+checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
 dependencies = [
  "zerofrom-derive",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2837,9 +2837,9 @@ checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "s3ls-rs"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37b7d3719dc4d6441db23c0168888a5524c7e29129748add848da0aa694f9735"
+checksum = "a7316b1059d13d7bdc93c4cddf1fd7d82b8afcf2731509cc8cd52bdc356470f2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2873,9 +2873,9 @@ dependencies = [
 
 [[package]]
 name = "s3rm-rs"
-version = "1.3.6"
+version = "1.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d087bd242c7986a9c1a5077bccbba0e75d3919e94358e2a4e8f9a78dad2babf1"
+checksum = "5498462e3cc0edbf64677bff74396fd616aea6adaaa382718148f2212a041a16"
 dependencies = [
  "anyhow",
  "async-channel",
@@ -2915,9 +2915,9 @@ dependencies = [
 
 [[package]]
 name = "s3sync"
-version = "1.58.7"
+version = "1.58.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a624c51919398ff1b1054291b32a45ba11b637921be674bda490a77867da639f"
+checksum = "b88eeb72af7ddbf09acc85216fb1baf00a664b5a03e74252feef3e9bb7e76a35"
 dependencies = [
  "anyhow",
  "async-channel",
@@ -3037,7 +3037,7 @@ dependencies = [
 
 [[package]]
 name = "s7cmd"
-version = "1.2.5"
+version = "1.3.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ categories = ["command-line-utilities", "filesystem"]
 # (--filter-callback-lua-script, etc.) automatically appear under
 # `s7cmd sync --help`. Use default-features = false to opt out.
 s3sync     = "=1.58.7"
-s3util-rs  = "=1.5.0"
+s3util-rs  = "=1.5.2"
 # Vendored bin code is sourced from these versions; pin minor.
 s3rm-rs    = "=1.3.6"
 s3ls-rs    = "=1.0.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "s7cmd"
-version = "1.2.4"
+version = "1.2.5"
 edition = "2024"
 rust-version = "1.91.1"
 license = "Apache-2.0"
@@ -28,7 +28,7 @@ shadow-rs = { version = "2", optional = true, default-features = false }
 # Re-export the same AWS SDK minor versions both libs use so Cargo unifies
 # the dep tree (otherwise you get two compiled copies and possible type
 # incompatibilities at API boundaries).
-aws-sdk-s3 = { version = "1.131", default-features = false, features = ["sigv4a", "http-1x", "default-https-client", "rt-tokio"] }
+aws-sdk-s3 = { version = "1.133", default-features = false, features = ["sigv4a", "http-1x", "default-https-client", "rt-tokio"] }
 aws-config = { version = "1.8", default-features = false, features = ["behavior-version-latest", "default-https-client", "rt-tokio", "credentials-process", "sso"] }
 aws-smithy-runtime-api = "1.12"
 aws-smithy-types       = "1.4"
@@ -38,7 +38,7 @@ anyhow       = "1"
 clap         = { version = "4.6", features = ["derive", "env", "cargo", "string", "wrap_help"] }
 clap_complete = "4.6"
 # Used by the new batch_run module (line tokenization).
-shlex = "1"
+shlex = "2"
 # Used by batch_run for verbosity-driven tracing config (-v / -vv / -q / -qq).
 # Already a transitive dep via s3util-rs; declare it directly so version is locked.
 clap-verbosity-flag = "3"
@@ -90,7 +90,7 @@ nix = { version = "0.31", default-features = false, features = ["signal"] }
 # Used by e2e_presign.rs to fetch presigned URLs and assert HTTP status / body.
 # Pulled in unconditionally as a dev-dep so cfg(e2e_test) compiles cleanly
 # everywhere; the test file itself gates on cfg(e2e_test).
-ureq = "2"
+ureq = "3"
 
 [profile.release]
 debug      = 1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ categories = ["command-line-utilities", "filesystem"]
 # (--filter-callback-lua-script, etc.) automatically appear under
 # `s7cmd sync --help`. Use default-features = false to opt out.
 s3sync     = "=1.58.7"
-s3util-rs  = "=1.4.0"
+s3util-rs  = "=1.5.0"
 # Vendored bin code is sourced from these versions; pin minor.
 s3rm-rs    = "=1.3.6"
 s3ls-rs    = "=1.0.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "s7cmd"
-version = "1.2.5"
+version = "1.3.0"
 edition = "2024"
 rust-version = "1.91.1"
 license = "Apache-2.0"
@@ -16,11 +16,11 @@ categories = ["command-line-utilities", "filesystem"]
 # s3sync's `lua_support` is in its default features; Lua flags
 # (--filter-callback-lua-script, etc.) automatically appear under
 # `s7cmd sync --help`. Use default-features = false to opt out.
-s3sync     = "=1.58.7"
+s3sync     = "=1.58.8"
 s3util-rs  = "=1.5.2"
 # Vendored bin code is sourced from these versions; pin minor.
-s3rm-rs    = "=1.3.6"
-s3ls-rs    = "=1.0.1"
+s3rm-rs    = "=1.3.7"
+s3ls-rs    = "=1.0.2"
 
 # Build-info for `s7cmd --version` (gated behind the `version` feature).
 shadow-rs = { version = "2", optional = true, default-features = false }

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ A reliable, flexible, and fast command-line tool for Amazon S3.
 
 s7cmd combines the speed of a Rust async runtime with the breadth of
 the AWS S3 API surface, providing high-throughput object operations
-(`ls`, `cp`, `mv`, `rm`, `sync`, `clean`) alongside comprehensive
+(`ls`, `cp`, `mv`, `rename`, `rm`, `sync`, `clean`) alongside comprehensive
 bucket administration (lifecycle, policy, encryption, CORS, public
 access block, website, logging, notification, and more) — all from a
 single static binary.
@@ -61,6 +61,7 @@ Object Operations:
   ls                                    List S3 objects
   cp                                    Copy objects from/to S3 (or S3 to S3)
   mv                                    Move objects from/to S3 (copy then delete source)
+  rename                                Rename an S3 object within an Express One Zone bucket
   rm                                    Delete a single S3 object
   restore-object                        Restore an archived S3 object
   presign                               Generate a pre-signed URL for an S3 object (GET only)
@@ -427,7 +428,7 @@ library. For details on flags, semantics, and exit codes, refer to:
 | `ls`                               | [s3ls-rs](https://github.com/nidor1998/s3ls-rs)        |
 | `sync`                             | [s3sync](https://github.com/nidor1998/s3sync)          |
 | `clean`                            | [s3rm-rs](https://github.com/nidor1998/s3rm-rs)        |
-| `cp`, `mv`, `rm`, and all others   | [s3util-rs](https://github.com/nidor1998/s3util-rs)    |
+| `cp`, `mv`, `rename`, `rm`, and all others | [s3util-rs](https://github.com/nidor1998/s3util-rs)    |
 | `batch-run`                        | s7cmd-only — see the section above                     |
 
 Each of these projects (except `batch-run`) also ships its own
@@ -462,9 +463,10 @@ Discussions about the legitimacy, licensing, or ethics of AI-generated code in g
 
 s7cmd is designed to cover **Amazon S3 object operations and bucket
 management** — listing (`ls`), single- and bulk-object transfers
-(`cp` / `mv` / `rm`), recursive synchronization (`sync`), bulk delete
-(`clean`), archive restoration (`restore-object`), pre-signed URL
-generation (`presign`), and the common bucket-level configurations
+(`cp` / `mv` / `rm`), atomic server-side rename (`rename`), recursive
+synchronization (`sync`), bulk delete (`clean`), archive restoration
+(`restore-object`), pre-signed URL generation (`presign`), and the
+common bucket-level configurations
 (tagging, versioning, policy, policy-status, lifecycle, encryption,
 CORS, public-access-block, website, logging, notification,
 replication, transfer acceleration, request payment). For any S3 use

--- a/src/batch_run/validate.rs
+++ b/src/batch_run/validate.rs
@@ -82,13 +82,14 @@ fn reject_per_line_stdin_config(_line_no: usize, _raw: &str, cmd: &Cmd) -> Resul
 ///   - Sync (s3sync::CLIArgs): top-level fields are private — read them
 ///     via `s3sync::Config::try_from(...)`.
 fn reject_per_line_tracing(_line_no: usize, _raw: &str, cmd: &Cmd) -> Result<()> {
+    // Accept the tracing-fields struct directly so callers pass `a.common`
+    // for args with a `.common` wrapper, or `a` for flat args (Ls, Clean, Rename).
     macro_rules! check_common {
-        ($a:expr) => {{
-            let c = &$a.common;
-            if c.json_tracing
-                || c.aws_sdk_tracing
-                || c.span_events_tracing
-                || c.disable_color_tracing
+        ($c:expr) => {{
+            if $c.json_tracing
+                || $c.aws_sdk_tracing
+                || $c.span_events_tracing
+                || $c.disable_color_tracing
             {
                 return Err(tracing_error());
             }
@@ -98,26 +99,10 @@ fn reject_per_line_tracing(_line_no: usize, _raw: &str, cmd: &Cmd) -> Result<()>
         // Already handled by validate() before this fn runs:
         Cmd::BatchRun(_) => {}
 
-        // s3ls_rs / s3rm_rs CLIArgs expose tracing fields as public
-        // top-level fields (no `.common` wrapper).
-        Cmd::Ls(boxed) => {
-            if boxed.json_tracing
-                || boxed.aws_sdk_tracing
-                || boxed.span_events_tracing
-                || boxed.disable_color_tracing
-            {
-                return Err(tracing_error());
-            }
-        }
-        Cmd::Clean(boxed) => {
-            if boxed.json_tracing
-                || boxed.aws_sdk_tracing
-                || boxed.span_events_tracing
-                || boxed.disable_color_tracing
-            {
-                return Err(tracing_error());
-            }
-        }
+        // s3ls_rs / s3rm_rs CLIArgs and RenameArgs expose tracing fields as
+        // public top-level fields (no `.common` wrapper).
+        Cmd::Ls(boxed) => check_common!(boxed),
+        Cmd::Clean(boxed) => check_common!(boxed),
 
         // s3sync::CLIArgs has private tracing fields, but exposes them
         // through `Config::try_from(...).tracing_config`. The conversion
@@ -141,56 +126,58 @@ fn reject_per_line_tracing(_line_no: usize, _raw: &str, cmd: &Cmd) -> Result<()>
             }
         }
 
-        // Cp/Mv: args.common is CommonTransferArgs.
-        Cmd::Cp(a) => check_common!(a),
-        Cmd::Mv(a) => check_common!(a),
+        // Cp/Mv: tracing fields live in args.common (CommonTransferArgs).
+        Cmd::Cp(a) => check_common!(a.common),
+        Cmd::Mv(a) => check_common!(a.common),
+        // Rename: tracing fields are top-level (no .common wrapper).
+        Cmd::Rename(a) => check_common!(a),
 
-        // Rm + bucket/object subcommands: args.common is CommonClientArgs.
-        Cmd::Rm(a) => check_common!(a),
-        Cmd::CreateBucket(a) => check_common!(a),
-        Cmd::DeleteBucket(a) => check_common!(a),
-        Cmd::HeadBucket(a) => check_common!(a),
-        Cmd::HeadObject(a) => check_common!(a),
-        Cmd::GetObjectTagging(a) => check_common!(a),
-        Cmd::PutObjectTagging(a) => check_common!(a),
-        Cmd::DeleteObjectTagging(a) => check_common!(a),
-        Cmd::GetBucketTagging(a) => check_common!(a),
-        Cmd::PutBucketTagging(a) => check_common!(a),
-        Cmd::DeleteBucketTagging(a) => check_common!(a),
-        Cmd::GetBucketPolicy(a) => check_common!(a),
-        Cmd::PutBucketPolicy(a) => check_common!(a),
-        Cmd::DeleteBucketPolicy(a) => check_common!(a),
-        Cmd::GetBucketVersioning(a) => check_common!(a),
-        Cmd::PutBucketVersioning(a) => check_common!(a),
-        Cmd::GetBucketLifecycleConfiguration(a) => check_common!(a),
-        Cmd::PutBucketLifecycleConfiguration(a) => check_common!(a),
-        Cmd::DeleteBucketLifecycleConfiguration(a) => check_common!(a),
-        Cmd::GetBucketEncryption(a) => check_common!(a),
-        Cmd::PutBucketEncryption(a) => check_common!(a),
-        Cmd::DeleteBucketEncryption(a) => check_common!(a),
-        Cmd::GetBucketCors(a) => check_common!(a),
-        Cmd::PutBucketCors(a) => check_common!(a),
-        Cmd::DeleteBucketCors(a) => check_common!(a),
-        Cmd::GetPublicAccessBlock(a) => check_common!(a),
-        Cmd::PutPublicAccessBlock(a) => check_common!(a),
-        Cmd::DeletePublicAccessBlock(a) => check_common!(a),
-        Cmd::GetBucketWebsite(a) => check_common!(a),
-        Cmd::PutBucketWebsite(a) => check_common!(a),
-        Cmd::DeleteBucketWebsite(a) => check_common!(a),
-        Cmd::GetBucketLogging(a) => check_common!(a),
-        Cmd::PutBucketLogging(a) => check_common!(a),
-        Cmd::GetBucketNotificationConfiguration(a) => check_common!(a),
-        Cmd::PutBucketNotificationConfiguration(a) => check_common!(a),
-        Cmd::GetBucketReplication(a) => check_common!(a),
-        Cmd::PutBucketReplication(a) => check_common!(a),
-        Cmd::DeleteBucketReplication(a) => check_common!(a),
-        Cmd::GetBucketAccelerateConfiguration(a) => check_common!(a),
-        Cmd::PutBucketAccelerateConfiguration(a) => check_common!(a),
-        Cmd::GetBucketRequestPayment(a) => check_common!(a),
-        Cmd::PutBucketRequestPayment(a) => check_common!(a),
-        Cmd::GetBucketPolicyStatus(a) => check_common!(a),
-        Cmd::RestoreObject(a) => check_common!(a),
-        Cmd::Presign(a) => check_common!(a),
+        // Rm + bucket/object subcommands: tracing fields in args.common (CommonClientArgs).
+        Cmd::Rm(a) => check_common!(a.common),
+        Cmd::CreateBucket(a) => check_common!(a.common),
+        Cmd::DeleteBucket(a) => check_common!(a.common),
+        Cmd::HeadBucket(a) => check_common!(a.common),
+        Cmd::HeadObject(a) => check_common!(a.common),
+        Cmd::GetObjectTagging(a) => check_common!(a.common),
+        Cmd::PutObjectTagging(a) => check_common!(a.common),
+        Cmd::DeleteObjectTagging(a) => check_common!(a.common),
+        Cmd::GetBucketTagging(a) => check_common!(a.common),
+        Cmd::PutBucketTagging(a) => check_common!(a.common),
+        Cmd::DeleteBucketTagging(a) => check_common!(a.common),
+        Cmd::GetBucketPolicy(a) => check_common!(a.common),
+        Cmd::PutBucketPolicy(a) => check_common!(a.common),
+        Cmd::DeleteBucketPolicy(a) => check_common!(a.common),
+        Cmd::GetBucketVersioning(a) => check_common!(a.common),
+        Cmd::PutBucketVersioning(a) => check_common!(a.common),
+        Cmd::GetBucketLifecycleConfiguration(a) => check_common!(a.common),
+        Cmd::PutBucketLifecycleConfiguration(a) => check_common!(a.common),
+        Cmd::DeleteBucketLifecycleConfiguration(a) => check_common!(a.common),
+        Cmd::GetBucketEncryption(a) => check_common!(a.common),
+        Cmd::PutBucketEncryption(a) => check_common!(a.common),
+        Cmd::DeleteBucketEncryption(a) => check_common!(a.common),
+        Cmd::GetBucketCors(a) => check_common!(a.common),
+        Cmd::PutBucketCors(a) => check_common!(a.common),
+        Cmd::DeleteBucketCors(a) => check_common!(a.common),
+        Cmd::GetPublicAccessBlock(a) => check_common!(a.common),
+        Cmd::PutPublicAccessBlock(a) => check_common!(a.common),
+        Cmd::DeletePublicAccessBlock(a) => check_common!(a.common),
+        Cmd::GetBucketWebsite(a) => check_common!(a.common),
+        Cmd::PutBucketWebsite(a) => check_common!(a.common),
+        Cmd::DeleteBucketWebsite(a) => check_common!(a.common),
+        Cmd::GetBucketLogging(a) => check_common!(a.common),
+        Cmd::PutBucketLogging(a) => check_common!(a.common),
+        Cmd::GetBucketNotificationConfiguration(a) => check_common!(a.common),
+        Cmd::PutBucketNotificationConfiguration(a) => check_common!(a.common),
+        Cmd::GetBucketReplication(a) => check_common!(a.common),
+        Cmd::PutBucketReplication(a) => check_common!(a.common),
+        Cmd::DeleteBucketReplication(a) => check_common!(a.common),
+        Cmd::GetBucketAccelerateConfiguration(a) => check_common!(a.common),
+        Cmd::PutBucketAccelerateConfiguration(a) => check_common!(a.common),
+        Cmd::GetBucketRequestPayment(a) => check_common!(a.common),
+        Cmd::PutBucketRequestPayment(a) => check_common!(a.common),
+        Cmd::GetBucketPolicyStatus(a) => check_common!(a.common),
+        Cmd::RestoreObject(a) => check_common!(a.common),
+        Cmd::Presign(a) => check_common!(a.common),
     }
     Ok(())
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -37,6 +37,7 @@ Object Operations:
   ls                                    List S3 objects
   cp                                    Copy objects from/to S3 (or S3 to S3)
   mv                                    Move objects from/to S3 (copy then delete source)
+  rename                                Rename an S3 object within an Express One Zone bucket
   rm                                    Delete a single S3 object
   restore-object                        Restore an archived S3 object
   presign                               Generate a pre-signed URL for an S3 object (GET only)
@@ -242,6 +243,8 @@ pub enum Cmd {
     Cp(s3util_rs::config::args::CpArgs),
     /// Move objects from/to S3 (copy then delete source)
     Mv(s3util_rs::config::args::MvArgs),
+    /// Rename an S3 object within an Express One Zone bucket (atomic server-side rename)
+    Rename(s3util_rs::config::args::RenameArgs),
     /// Delete a single S3 object
     Rm(s3util_rs::config::args::RmArgs),
     /// Restore an archived S3 object

--- a/src/dispatch.rs
+++ b/src/dispatch.rs
@@ -139,6 +139,21 @@ pub async fn dispatch(cmd: Cmd) -> i32 {
             }
         }
 
+        Cmd::Rename(args) => {
+            if let Err(e) = args.validate() {
+                let _ = clap::Error::raw(clap::error::ErrorKind::ValueValidation, e).print();
+                return 2;
+            }
+            let client_config = args.build_client_config();
+            match util_bin::cli::run_rename(args, client_config).await {
+                Ok(status) => status.code(),
+                Err(e) => {
+                    tracing::error!(error = format!("{e:#}"));
+                    util_bin::cli::EXIT_CODE_ERROR
+                }
+            }
+        }
+
         // Rm and bucket/object metadata commands all use the same shape:
         // build_client_config -> run with (args, config) -> map result to i32.
         // Use the helpers below to avoid 35 near-identical arms. Tracing init

--- a/src/main.rs
+++ b/src/main.rs
@@ -67,6 +67,7 @@ fn init_tracing_for(cmd: &Cmd) {
         // sync_bin / ls_bin / clean_bin / cp / mv handle their own subscriber
         // init inside their dispatch arms.
         Cmd::Sync(_) | Cmd::Ls(_) | Cmd::Clean(_) | Cmd::Cp(_) | Cmd::Mv(_) => return,
+        Cmd::Rename(args) => args.build_tracing_config_dry_run(args.dry_run),
         Cmd::Rm(args) => args.common.build_tracing_config_dry_run(args.dry_run),
         Cmd::CreateBucket(args) => args.common.build_tracing_config_dry_run(args.dry_run),
         Cmd::DeleteBucket(args) => args.common.build_tracing_config_dry_run(args.dry_run),

--- a/src/util_bin/cli/mod.rs
+++ b/src/util_bin/cli/mod.rs
@@ -72,6 +72,7 @@ pub mod put_bucket_versioning;
 pub mod put_bucket_website;
 pub mod put_object_tagging;
 pub mod put_public_access_block;
+pub mod rename;
 pub mod restore_object;
 pub mod rm;
 
@@ -120,6 +121,7 @@ pub use put_bucket_versioning::run_put_bucket_versioning;
 pub use put_bucket_website::run_put_bucket_website;
 pub use put_object_tagging::run_put_object_tagging;
 pub use put_public_access_block::run_put_public_access_block;
+pub use rename::run_rename;
 pub use restore_object::run_restore_object;
 pub use rm::run_rm;
 

--- a/src/util_bin/cli/rename.rs
+++ b/src/util_bin/cli/rename.rs
@@ -1,4 +1,4 @@
-// Vendored from s3util-rs@1.5.0 src/bin/s3util/cli/rename.rs
+// Vendored from s3util-rs@1.5.2 src/bin/s3util/cli/rename.rs
 use anyhow::Result;
 use tracing::info;
 
@@ -27,17 +27,6 @@ pub async fn run_rename(args: RenameArgs, client_config: ClientConfig) -> Result
         return Ok(ExitStatus::Success);
     }
 
-    let source_if_none_match = if args.source_if_none_match {
-        Some("*")
-    } else {
-        None
-    };
-    let target_if_none_match = if args.target_if_none_match {
-        Some("*")
-    } else {
-        None
-    };
-
     match api::rename_object(
         &client,
         &src_bucket,
@@ -45,9 +34,9 @@ pub async fn run_rename(args: RenameArgs, client_config: ClientConfig) -> Result
         &dst_key,
         RenameObjectConditions {
             source_if_match: args.source_if_match.as_deref(),
-            source_if_none_match,
+            source_if_none_match: args.source_if_none_match.as_deref(),
             destination_if_match: args.target_if_match.as_deref(),
-            destination_if_none_match: target_if_none_match,
+            destination_if_none_match: args.target_if_none_match.as_deref(),
         },
     )
     .await

--- a/src/util_bin/cli/rename.rs
+++ b/src/util_bin/cli/rename.rs
@@ -1,0 +1,71 @@
+// Vendored from s3util-rs@1.5.0 src/bin/s3util/cli/rename.rs
+use anyhow::Result;
+use tracing::info;
+
+use s3util_rs::config::ClientConfig;
+use s3util_rs::config::args::rename::RenameArgs;
+use s3util_rs::storage::s3::api::{self, HeadError, RenameObjectConditions};
+
+use super::ExitStatus;
+
+pub async fn run_rename(args: RenameArgs, client_config: ClientConfig) -> Result<ExitStatus> {
+    let (src_bucket, src_key) = args
+        .source_bucket_key()
+        .map_err(|e| anyhow::anyhow!("{}", e.trim_end()))?;
+    let (_, dst_key) = args
+        .target_bucket_key()
+        .map_err(|e| anyhow::anyhow!("{}", e.trim_end()))?;
+
+    let client = client_config.create_client().await;
+
+    if args.dry_run {
+        info!(
+            source = %format!("s3://{src_bucket}/{src_key}"),
+            target = %format!("s3://{src_bucket}/{dst_key}"),
+            "[dry-run] would rename object."
+        );
+        return Ok(ExitStatus::Success);
+    }
+
+    let source_if_none_match = if args.source_if_none_match {
+        Some("*")
+    } else {
+        None
+    };
+    let target_if_none_match = if args.target_if_none_match {
+        Some("*")
+    } else {
+        None
+    };
+
+    match api::rename_object(
+        &client,
+        &src_bucket,
+        &src_key,
+        &dst_key,
+        RenameObjectConditions {
+            source_if_match: args.source_if_match.as_deref(),
+            source_if_none_match,
+            destination_if_match: args.target_if_match.as_deref(),
+            destination_if_none_match: target_if_none_match,
+        },
+    )
+    .await
+    {
+        Ok(_) => {
+            info!(
+                source = %format!("s3://{src_bucket}/{src_key}"),
+                target = %format!("s3://{src_bucket}/{dst_key}"),
+                "Object renamed."
+            );
+            Ok(ExitStatus::Success)
+        }
+        Err(HeadError::BucketNotFound) => {
+            Err(anyhow::anyhow!("bucket s3://{src_bucket} not found"))
+        }
+        Err(HeadError::NotFound) => Err(anyhow::anyhow!(
+            "object s3://{src_bucket}/{src_key} not found"
+        )),
+        Err(HeadError::Other(e)) => Err(e),
+    }
+}

--- a/tests/cli_rename.rs
+++ b/tests/cli_rename.rs
@@ -153,6 +153,7 @@ fn rename_source_if_match_and_source_if_none_match_are_mutually_exclusive() {
             "--source-if-match",
             "\"abc123\"",
             "--source-if-none-match",
+            "\"def456\"",
         ])
         .assert()
         .failure()
@@ -169,6 +170,67 @@ fn rename_target_if_match_and_target_if_none_match_are_mutually_exclusive() {
             "--target-if-match",
             "\"abc123\"",
             "--target-if-none-match",
+            "\"def456\"",
+        ])
+        .assert()
+        .failure()
+        .code(2);
+}
+
+#[test]
+fn rename_empty_source_if_match_exits_2() {
+    s7cmd()
+        .args([
+            "rename",
+            &format!("{EXPR_BUCKET}/src"),
+            &format!("{EXPR_BUCKET}/dst"),
+            "--source-if-match",
+            "",
+        ])
+        .assert()
+        .failure()
+        .code(2);
+}
+
+#[test]
+fn rename_empty_source_if_none_match_exits_2() {
+    s7cmd()
+        .args([
+            "rename",
+            &format!("{EXPR_BUCKET}/src"),
+            &format!("{EXPR_BUCKET}/dst"),
+            "--source-if-none-match",
+            "",
+        ])
+        .assert()
+        .failure()
+        .code(2);
+}
+
+#[test]
+fn rename_empty_target_if_match_exits_2() {
+    s7cmd()
+        .args([
+            "rename",
+            &format!("{EXPR_BUCKET}/src"),
+            &format!("{EXPR_BUCKET}/dst"),
+            "--target-if-match",
+            "",
+        ])
+        .assert()
+        .failure()
+        .code(2);
+}
+
+#[test]
+fn rename_empty_target_if_none_match_exits_2() {
+    s7cmd()
+        .args([
+            "rename",
+            &format!("{EXPR_BUCKET}/src"),
+            &format!("{EXPR_BUCKET}/dst"),
+            "--target-if-none-match",
+            "",
         ])
         .assert()
         .failure()

--- a/tests/cli_rename.rs
+++ b/tests/cli_rename.rs
@@ -1,0 +1,176 @@
+//! Process-level CLI tests for the `rename` subcommand.
+//! These run without AWS credentials or network access.
+
+use assert_cmd::Command;
+use predicates::prelude::*;
+
+fn s7cmd() -> Command {
+    Command::cargo_bin("s7cmd").unwrap()
+}
+
+// Express One Zone bucket name usable in no-AWS tests: passes validate() because
+// the bucket ends with --x-s3, and source/target share the same bucket name.
+const EXPR_BUCKET: &str = "s3://fake-bucket--apne1-az4--x-s3";
+
+#[test]
+fn rename_help_succeeds_and_lists_option_groups() {
+    s7cmd()
+        .args(["rename", "--help"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("AWS Configuration"))
+        .stdout(predicate::str::contains("Conditional Checks"))
+        .stdout(predicate::str::contains("--source-if-match"))
+        .stdout(predicate::str::contains("--target-if-none-match"))
+        .stdout(predicate::str::contains("--dry-run"));
+}
+
+#[test]
+fn rename_top_level_help_lists_rename() {
+    s7cmd()
+        .arg("--help")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("rename"));
+}
+
+#[test]
+fn rename_missing_args_exits_2() {
+    s7cmd().arg("rename").assert().failure().code(2);
+}
+
+#[test]
+fn rename_missing_target_exits_2() {
+    s7cmd()
+        .args(["rename", &format!("{EXPR_BUCKET}/src-key")])
+        .assert()
+        .failure()
+        .code(2);
+}
+
+// NOTE: s3util-rs's auto_complete_shell_short_circuits_without_positional_args test
+// is omitted — s7cmd hides the per-subcommand --auto-complete-shell flag (see
+// cli_command() in src/cli.rs). The top-level `s7cmd --auto-complete-shell bash`
+// form is tested in tests/cli_help.rs.
+
+#[test]
+fn rename_source_bucket_only_exits_2() {
+    // s3://bucket with no key → validate() → source_bucket_key() error → exit 2
+    s7cmd()
+        .args([
+            "rename",
+            "s3://fake-bucket--apne1-az4--x-s3",
+            &format!("{EXPR_BUCKET}/dst"),
+        ])
+        .assert()
+        .failure()
+        .code(2);
+}
+
+#[test]
+fn rename_target_bucket_only_exits_2() {
+    // source is valid, but target has no key → exit 2
+    s7cmd()
+        .args([
+            "rename",
+            &format!("{EXPR_BUCKET}/src"),
+            "s3://fake-bucket--apne1-az4--x-s3",
+        ])
+        .assert()
+        .failure()
+        .code(2);
+}
+
+#[test]
+fn rename_non_express_onezone_bucket_exits_2() {
+    s7cmd()
+        .args([
+            "rename",
+            "s3://regular-bucket/src-key",
+            "s3://regular-bucket/dst-key",
+        ])
+        .assert()
+        .failure()
+        .code(2)
+        .stderr(predicate::str::contains("Express").or(predicate::str::contains("x-s3")));
+}
+
+#[test]
+fn rename_different_buckets_exits_2() {
+    s7cmd()
+        .args([
+            "rename",
+            "s3://bucket-a--apne1-az4--x-s3/src-key",
+            "s3://bucket-b--apne1-az4--x-s3/dst-key",
+        ])
+        .assert()
+        .failure()
+        .code(2)
+        .stderr(predicate::str::contains("same bucket"));
+}
+
+#[test]
+fn rename_source_access_key_without_secret_exits_2() {
+    s7cmd()
+        .args([
+            "rename",
+            &format!("{EXPR_BUCKET}/src"),
+            &format!("{EXPR_BUCKET}/dst"),
+            "--source-access-key",
+            "AKIAIOSFODNN7EXAMPLE",
+        ])
+        .assert()
+        .failure()
+        .code(2);
+}
+
+#[test]
+fn rename_source_profile_conflicts_with_access_key_exits_2() {
+    s7cmd()
+        .args([
+            "rename",
+            &format!("{EXPR_BUCKET}/src"),
+            &format!("{EXPR_BUCKET}/dst"),
+            "--source-profile",
+            "myprofile",
+            "--source-access-key",
+            "AKID",
+            "--source-secret-access-key",
+            "SECRET",
+        ])
+        .assert()
+        .failure()
+        .code(2);
+}
+
+#[test]
+fn rename_source_if_match_and_source_if_none_match_are_mutually_exclusive() {
+    s7cmd()
+        .args([
+            "rename",
+            &format!("{EXPR_BUCKET}/src"),
+            &format!("{EXPR_BUCKET}/dst"),
+            "--source-if-match",
+            "\"abc123\"",
+            "--source-if-none-match",
+        ])
+        .assert()
+        .failure()
+        .code(2);
+}
+
+#[test]
+fn rename_target_if_match_and_target_if_none_match_are_mutually_exclusive() {
+    s7cmd()
+        .args([
+            "rename",
+            &format!("{EXPR_BUCKET}/src"),
+            &format!("{EXPR_BUCKET}/dst"),
+            "--target-if-match",
+            "\"abc123\"",
+            "--target-if-none-match",
+        ])
+        .assert()
+        .failure()
+        .code(2);
+}

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -80,7 +80,7 @@ pub fn create_sized_file(dir: &Path, name: &str, size: usize) -> PathBuf {
 // the false-positive locally.
 #[cfg(e2e_test)]
 #[allow(unused_imports)]
-pub use e2e::{REGION, TestHelper};
+pub use e2e::{EXPRESS_ONE_ZONE_AZ, REGION, TestHelper};
 
 #[cfg(e2e_test)]
 mod e2e {
@@ -91,8 +91,10 @@ mod e2e {
     use aws_sdk_s3::Client;
     use aws_sdk_s3::config::Region;
     use aws_sdk_s3::operation::get_object_tagging::GetObjectTaggingOutput;
+    use aws_sdk_s3::operation::head_object::HeadObjectOutput;
     use aws_sdk_s3::types::{
-        BucketLocationConstraint, BucketVersioningStatus, CreateBucketConfiguration, Tag, Tagging,
+        BucketInfo, BucketLocationConstraint, BucketType, BucketVersioningStatus,
+        CreateBucketConfiguration, DataRedundancy, LocationInfo, LocationType, Tag, Tagging,
         VersioningConfiguration,
     };
 
@@ -100,6 +102,9 @@ mod e2e {
     /// `S7CMD_E2E_REGION` environment variable, so a single binary can be
     /// pointed at different accounts/regions without recompiling.
     pub const REGION: &str = "ap-northeast-1";
+
+    /// Availability Zone ID used for Express One Zone directory bucket tests.
+    pub const EXPRESS_ONE_ZONE_AZ: &str = "apne1-az4";
 
     pub struct TestHelper {
         pub client: Client,
@@ -425,6 +430,58 @@ mod e2e {
                         .await;
                 }
             }
+        }
+
+        // ---- Express One Zone directory bucket helpers (rename tests) ----
+
+        pub async fn create_directory_bucket(&self, bucket_name: &str, availability_zone: &str) {
+            let location_info = LocationInfo::builder()
+                .r#type(LocationType::AvailabilityZone)
+                .name(availability_zone)
+                .build();
+            let bucket_info = BucketInfo::builder()
+                .data_redundancy(DataRedundancy::SingleAvailabilityZone)
+                .r#type(BucketType::Directory)
+                .build();
+            let configuration = CreateBucketConfiguration::builder()
+                .location(location_info)
+                .bucket(bucket_info)
+                .build();
+            self.client
+                .create_bucket()
+                .create_bucket_configuration(configuration)
+                .bucket(bucket_name)
+                .send()
+                .await
+                .expect("create_directory_bucket");
+        }
+
+        /// HeadObject and return the full output. Used by rename tests to
+        /// obtain the ETag for conditional-check flags.
+        pub async fn head_object(
+            &self,
+            bucket: &str,
+            key: &str,
+            version_id: Option<String>,
+        ) -> HeadObjectOutput {
+            self.client
+                .head_object()
+                .bucket(bucket)
+                .key(key)
+                .set_version_id(version_id)
+                .send()
+                .await
+                .expect("head_object")
+        }
+
+        /// Empty a directory bucket (no versioning support) and delete it.
+        /// Idempotent: no-op when the bucket does not exist.
+        pub async fn delete_directory_bucket_with_cascade(&self, bucket: &str) {
+            if !self.is_bucket_exist(bucket).await {
+                return;
+            }
+            self.delete_all_objects(bucket).await;
+            let _ = self.client.delete_bucket().bucket(bucket).send().await;
         }
     }
 }

--- a/tests/e2e_batch_run.rs
+++ b/tests/e2e_batch_run.rs
@@ -17,7 +17,8 @@ mod common;
 
 use assert_cmd::Command as AssertCommand;
 use common::{
-    REGION, TestHelper, create_temp_dir, create_test_file, generate_bucket_name, run, s7cmd_cmd,
+    EXPRESS_ONE_ZONE_AZ, REGION, TestHelper, create_temp_dir, create_test_file,
+    generate_bucket_name, run, s7cmd_cmd,
 };
 use predicates::prelude::*;
 use std::path::Path;
@@ -878,6 +879,10 @@ fn sample_policy_inline(bucket: &str) -> String {
 async fn batch_run_e2e_all_subcommands_via_file() {
     let helper = TestHelper::new().await;
     let bucket = generate_bucket_name();
+    let expr_bucket = format!("s7cmd-e2e-{}--apne1-az4--x-s3", uuid::Uuid::new_v4());
+    helper
+        .create_directory_bucket(&expr_bucket, EXPRESS_ONE_ZONE_AZ)
+        .await;
 
     let local_dir = create_temp_dir();
     let payload = create_test_file(&local_dir, "payload.txt", b"hello all-subcommands");
@@ -923,12 +928,15 @@ async fn batch_run_e2e_all_subcommands_via_file() {
     let notification_path = create_test_file(&local_dir, "notification.json", b"{}");
 
     // Per-line auth flags. Most subcommands take target-only; mv
-    // s3://X → s3://X needs both source and target pairs.
+    // s3://X → s3://X needs both source and target pairs; rename
+    // uses only source-prefixed flags (source and target are in the
+    // same bucket).
     let auth_target = format!("--target-profile s7cmd-e2e-test --target-region {REGION}");
     let auth_both = format!(
         "--source-profile s7cmd-e2e-test --source-region {REGION} \
          --target-profile s7cmd-e2e-test --target-region {REGION}"
     );
+    let auth_source = format!("--source-profile s7cmd-e2e-test --source-region {REGION}");
 
     let payload_p = shell_path(&payload);
     let sync_p = shell_path(&sync_src);
@@ -997,6 +1005,8 @@ ls {auth_target} s3://{bucket}
 sync {auth_target} {sync_p} s3://{bucket}/synced/
 mv {auth_both} s3://{bucket}/object1 s3://{bucket}/object1-moved
 rm {auth_target} s3://{bucket}/object1-moved
+cp {auth_target} {payload_p} s3://{expr_bucket}/rename-src
+rename {auth_source} s3://{expr_bucket}/rename-src s3://{expr_bucket}/rename-dst
 clean --force {auth_target} s3://{bucket}
 
 # ---- versioning subcommand pair, on the now-empty bucket ----
@@ -1012,6 +1022,10 @@ delete-bucket-encryption {auth_target} s3://{bucket}
 delete-bucket-cors {auth_target} s3://{bucket}
 delete-bucket-website {auth_target} s3://{bucket}
 delete-bucket-replication {auth_target} s3://{bucket}
+
+# ---- Express One Zone bucket teardown (rename test) ----
+clean --force {auth_target} s3://{expr_bucket}
+delete-bucket {auth_target} s3://{expr_bucket}
 
 # ---- final teardown ----
 delete-bucket {auth_target} s3://{bucket}
@@ -1033,7 +1047,10 @@ delete-bucket {auth_target} s3://{bucket}
     );
 
     // Defensive cleanup in case any line failed before the final
-    // delete-bucket. delete_bucket_with_cascade is idempotent.
+    // delete-bucket. Both helpers are idempotent on already-gone buckets.
     helper.delete_bucket_with_cascade(&bucket).await;
+    helper
+        .delete_directory_bucket_with_cascade(&expr_bucket)
+        .await;
     let _ = std::fs::remove_dir_all(&local_dir);
 }

--- a/tests/e2e_presign.rs
+++ b/tests/e2e_presign.rs
@@ -24,16 +24,17 @@ const PROFILE: &str = "s7cmd-e2e-test";
 fn http_get(url: &str) -> (u16, Vec<u8>) {
     match ureq::get(url).call() {
         Ok(resp) => {
-            let status = resp.status();
+            let status = resp.status().as_u16();
             let mut body = Vec::new();
-            resp.into_reader()
+            resp.into_body()
+                .into_reader()
                 .read_to_end(&mut body)
                 .expect("read presigned-URL body");
             (status, body)
         }
-        // ureq returns Err for any 4xx/5xx; we still want the status code
-        // so the test can distinguish `expired` (403) from `missing` (404).
-        Err(ureq::Error::Status(code, _)) => (code, Vec::new()),
+        // ureq v3 returns Err(StatusCode(code)) for any 4xx/5xx; we still
+        // want the status code to distinguish `expired` (403) from `missing` (404).
+        Err(ureq::Error::StatusCode(code)) => (code, Vec::new()),
         Err(e) => panic!("HTTP transport error fetching presigned URL: {e}"),
     }
 }

--- a/tests/e2e_rename.rs
+++ b/tests/e2e_rename.rs
@@ -18,9 +18,11 @@
 //! - Source-not-found: exit 1, no crash.
 //! - Dry run: no actual rename, exit 0, `[dry-run]` in stderr.
 //! - Conditional `--source-if-match`: matching ETag succeeds, wrong ETag fails.
-//! - Conditional `--source-if-none-match`: flag always sends `*`; object exists
-//!   so the condition fails with 412 (precondition failure → exit 1).
-//! - Conditional `--target-if-none-match`: destination absent → succeeds;
+//! - Conditional `--source-if-none-match`: passing `*` means "rename only if
+//!   source has no ETag"; object exists so the condition fails with 412
+//!   (precondition failure → exit 1).
+//! - Conditional `--target-if-none-match`: passing `*` means "rename only if
+//!   destination has no ETag"; destination absent → succeeds;
 //!   destination present → precondition failure → exit 1.
 //! - Conditional `--target-if-match`: matching destination ETag succeeds;
 //!   wrong ETag fails.
@@ -303,9 +305,10 @@ async fn rename_source_if_match_wrong_etag_fails() {
 // Conditional checks — source-if-none-match (1 test)
 // ---------------------------------------------------------------
 
-/// `--source-if-none-match` always sends `*` internally. Because the
-/// source object exists, the condition "none match" is false and the API
-/// returns a 412 precondition failure. The source must remain intact.
+/// `--source-if-none-match *` means "rename only if the source has no ETag".
+/// Because the source object exists it always has an ETag, so the condition
+/// is false and the API returns a 412 precondition failure.
+/// The source must remain intact.
 #[tokio::test]
 async fn rename_source_if_none_match_existing_object_fails() {
     let helper = TestHelper::new().await;
@@ -322,6 +325,7 @@ async fn rename_source_if_none_match_existing_object_fails() {
         "--source-profile",
         PROFILE_NAME,
         "--source-if-none-match",
+        "*",
         &src,
         &dst,
     ]);
@@ -345,9 +349,9 @@ async fn rename_source_if_none_match_existing_object_fails() {
 // Conditional checks — target-if-none-match (2 tests)
 // ---------------------------------------------------------------
 
-/// `--target-if-none-match` always sends `*` internally. When the
-/// destination does not exist, the condition "none match any ETag" is
-/// true, so the rename succeeds.
+/// `--target-if-none-match *` means "rename only if the destination has no
+/// ETag". When the destination does not exist, no ETag is present, so the
+/// condition is true and the rename succeeds.
 #[tokio::test]
 async fn rename_target_if_none_match_destination_absent_succeeds() {
     let helper = TestHelper::new().await;
@@ -364,6 +368,7 @@ async fn rename_target_if_none_match_destination_absent_succeeds() {
         "--source-profile",
         PROFILE_NAME,
         "--target-if-none-match",
+        "*",
         &src,
         &dst,
     ]);
@@ -381,9 +386,10 @@ async fn rename_target_if_none_match_destination_absent_succeeds() {
     helper.delete_directory_bucket_with_cascade(&bucket).await;
 }
 
-/// `--target-if-none-match` always sends `*` internally. When the
-/// destination already exists, the condition is false and the API
-/// returns 412. Source and destination must remain unchanged.
+/// `--target-if-none-match *` means "rename only if the destination has no
+/// ETag". When the destination already exists it has an ETag, so the
+/// condition is false and the API returns 412.
+/// Source and destination must remain unchanged.
 #[tokio::test]
 async fn rename_target_if_none_match_destination_present_fails() {
     let helper = TestHelper::new().await;
@@ -402,6 +408,7 @@ async fn rename_target_if_none_match_destination_present_fails() {
         "--source-profile",
         PROFILE_NAME,
         "--target-if-none-match",
+        "*",
         &src,
         &dst,
     ]);

--- a/tests/e2e_rename.rs
+++ b/tests/e2e_rename.rs
@@ -1,0 +1,593 @@
+//! E2E tests for `s7cmd rename`.
+//!
+//! These tests hit real AWS and are reserved for the user to run. The
+//! CI executor only compile-checks them (under `RUSTFLAGS="--cfg e2e_test"`)
+//! to keep rename's end-to-end behavior covered without spending money or
+//! touching production buckets in CI.
+//!
+//! Run with:
+//! ```sh
+//! RUSTFLAGS="--cfg e2e_test" cargo test --test e2e_rename -- --test-threads=1
+//! ```
+//!
+//! Requires the `s7cmd-e2e-test` AWS profile to be configured.
+//!
+//! Coverage:
+//! - Basic rename: source key moves to destination, source no longer exists.
+//! - Content preservation: renamed object's bytes match the original.
+//! - Source-not-found: exit 1, no crash.
+//! - Dry run: no actual rename, exit 0, `[dry-run]` in stderr.
+//! - Conditional `--source-if-match`: matching ETag succeeds, wrong ETag fails.
+//! - Conditional `--source-if-none-match`: flag always sends `*`; object exists
+//!   so the condition fails with 412 (precondition failure → exit 1).
+//! - Conditional `--target-if-none-match`: destination absent → succeeds;
+//!   destination present → precondition failure → exit 1.
+//! - Conditional `--target-if-match`: matching destination ETag succeeds;
+//!   wrong ETag fails.
+//! - Special characters in key: spaces, slashes, Unicode percent-encoded correctly.
+//! - CLI validation: non-Express-One-Zone bucket name → exit 2.
+//! - CLI validation: source and target in different buckets → exit 2.
+
+#![cfg(e2e_test)]
+
+mod common;
+
+use common::{EXPRESS_ONE_ZONE_AZ, PROFILE_NAME, TestHelper};
+
+use std::process::{Command, Output, Stdio};
+
+/// Suffix appended to base bucket names to form Express One Zone directory bucket names.
+const EXPRESS_ONE_ZONE_BUCKET_SUFFIX: &str = "--apne1-az4--x-s3";
+
+const EXIT_CODE_SUCCESS: i32 = 0;
+const EXIT_CODE_ERROR: i32 = 1;
+const EXIT_CODE_CLAP_ARG_ERROR: i32 = 2;
+
+fn run_s7cmd(args: &[&str]) -> Output {
+    Command::new(env!("CARGO_BIN_EXE_s7cmd"))
+        .args(args)
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()
+        .expect("spawn s7cmd")
+}
+
+/// Create a fresh Express One Zone directory bucket, put a small object
+/// into it with the SDK, and return `(bucket_name, etag)`.
+async fn setup_bucket_with_object(helper: &TestHelper, key: &str, body: &[u8]) -> (String, String) {
+    let bucket = format!(
+        "s7e2e-{}{}",
+        uuid::Uuid::new_v4(),
+        EXPRESS_ONE_ZONE_BUCKET_SUFFIX
+    );
+    helper
+        .create_directory_bucket(&bucket, EXPRESS_ONE_ZONE_AZ)
+        .await;
+    helper.put_object(&bucket, key, body.to_vec()).await;
+    let head = helper.head_object(&bucket, key, None).await;
+    let etag = head.e_tag().unwrap().to_string();
+    (bucket, etag)
+}
+
+// ---------------------------------------------------------------
+// Basic rename (3 tests)
+// ---------------------------------------------------------------
+
+/// Happy path: rename an object within the same Express One Zone bucket.
+/// After rename: destination exists, source is gone.
+#[tokio::test]
+async fn rename_basic_source_gone_destination_present() {
+    let helper = TestHelper::new().await;
+    let src_key = "src/basic.txt";
+    let dst_key = "dst/basic.txt";
+    let body = b"rename basic test body";
+    let (bucket, _) = setup_bucket_with_object(&helper, src_key, body).await;
+
+    let src = format!("s3://{}/{}", bucket, src_key);
+    let dst = format!("s3://{}/{}", bucket, dst_key);
+
+    let output = run_s7cmd(&["rename", "--source-profile", PROFILE_NAME, &src, &dst]);
+
+    assert_eq!(
+        output.status.code(),
+        Some(EXIT_CODE_SUCCESS),
+        "rename must exit 0; stdout={}, stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+    assert!(
+        !helper.is_object_exist(&bucket, src_key, None).await,
+        "source must be gone after rename"
+    );
+    assert!(
+        helper.is_object_exist(&bucket, dst_key, None).await,
+        "destination must exist after rename"
+    );
+
+    helper.delete_directory_bucket_with_cascade(&bucket).await;
+}
+
+/// Rename preserves object content: bytes at destination match original.
+#[tokio::test]
+async fn rename_preserves_content() {
+    let helper = TestHelper::new().await;
+    let src_key = "preserve_src.txt";
+    let dst_key = "preserve_dst.txt";
+    let body = b"content to be preserved across rename";
+    let (bucket, _) = setup_bucket_with_object(&helper, src_key, body).await;
+
+    let src = format!("s3://{}/{}", bucket, src_key);
+    let dst = format!("s3://{}/{}", bucket, dst_key);
+
+    let output = run_s7cmd(&["rename", "--source-profile", PROFILE_NAME, &src, &dst]);
+
+    assert_eq!(
+        output.status.code(),
+        Some(EXIT_CODE_SUCCESS),
+        "rename must exit 0; stdout={}, stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+
+    let dst_bytes = helper.get_object_bytes(&bucket, dst_key, None).await;
+    assert_eq!(
+        dst_bytes, body,
+        "renamed object content must match original"
+    );
+
+    helper.delete_directory_bucket_with_cascade(&bucket).await;
+}
+
+/// Rename when the source key does not exist must exit 1 without panicking.
+#[tokio::test]
+async fn rename_missing_source_exits_error() {
+    let helper = TestHelper::new().await;
+    let bucket = format!(
+        "s7e2e-{}{}",
+        uuid::Uuid::new_v4(),
+        EXPRESS_ONE_ZONE_BUCKET_SUFFIX
+    );
+    helper
+        .create_directory_bucket(&bucket, EXPRESS_ONE_ZONE_AZ)
+        .await;
+
+    let src = format!("s3://{}/nonexistent.txt", bucket);
+    let dst = format!("s3://{}/dest.txt", bucket);
+
+    let output = run_s7cmd(&["rename", "--source-profile", PROFILE_NAME, &src, &dst]);
+
+    assert_eq!(
+        output.status.code(),
+        Some(EXIT_CODE_ERROR),
+        "rename of nonexistent source must exit 1; stdout={}, stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+
+    helper.delete_directory_bucket_with_cascade(&bucket).await;
+}
+
+// ---------------------------------------------------------------
+// Dry run (1 test)
+// ---------------------------------------------------------------
+
+/// `--dry-run` must exit 0, emit `[dry-run]` in stderr, and leave both
+/// source present and destination absent (no actual rename performed).
+#[tokio::test]
+async fn rename_dry_run_no_side_effects() {
+    let helper = TestHelper::new().await;
+    let src_key = "dryrun_src.txt";
+    let dst_key = "dryrun_dst.txt";
+    let body = b"dry run body";
+    let (bucket, _) = setup_bucket_with_object(&helper, src_key, body).await;
+
+    let src = format!("s3://{}/{}", bucket, src_key);
+    let dst = format!("s3://{}/{}", bucket, dst_key);
+
+    let output = run_s7cmd(&[
+        "rename",
+        "--source-profile",
+        PROFILE_NAME,
+        "--dry-run",
+        &src,
+        &dst,
+    ]);
+
+    assert_eq!(
+        output.status.code(),
+        Some(EXIT_CODE_SUCCESS),
+        "rename --dry-run must exit 0; stdout={}, stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("[dry-run]"),
+        "stderr must contain [dry-run] prefix; got: {stderr}"
+    );
+    assert!(
+        helper.is_object_exist(&bucket, src_key, None).await,
+        "source must still exist after --dry-run"
+    );
+    assert!(
+        !helper.is_object_exist(&bucket, dst_key, None).await,
+        "destination must not exist after --dry-run"
+    );
+
+    helper.delete_directory_bucket_with_cascade(&bucket).await;
+}
+
+// ---------------------------------------------------------------
+// Conditional checks — source-if-match (2 tests)
+// ---------------------------------------------------------------
+
+/// `--source-if-match <correct ETag>` must succeed and rename the object.
+#[tokio::test]
+async fn rename_source_if_match_correct_etag_succeeds() {
+    let helper = TestHelper::new().await;
+    let src_key = "sim_src.txt";
+    let dst_key = "sim_dst.txt";
+    let body = b"source-if-match test";
+    let (bucket, etag) = setup_bucket_with_object(&helper, src_key, body).await;
+
+    let src = format!("s3://{}/{}", bucket, src_key);
+    let dst = format!("s3://{}/{}", bucket, dst_key);
+
+    let output = run_s7cmd(&[
+        "rename",
+        "--source-profile",
+        PROFILE_NAME,
+        "--source-if-match",
+        &etag,
+        &src,
+        &dst,
+    ]);
+
+    assert_eq!(
+        output.status.code(),
+        Some(EXIT_CODE_SUCCESS),
+        "rename with correct --source-if-match must exit 0; stdout={}, stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+    assert!(!helper.is_object_exist(&bucket, src_key, None).await);
+    assert!(helper.is_object_exist(&bucket, dst_key, None).await);
+
+    helper.delete_directory_bucket_with_cascade(&bucket).await;
+}
+
+/// `--source-if-match <wrong ETag>` must fail (412 precondition) and
+/// leave the source object intact.
+#[tokio::test]
+async fn rename_source_if_match_wrong_etag_fails() {
+    let helper = TestHelper::new().await;
+    let src_key = "sim_fail_src.txt";
+    let dst_key = "sim_fail_dst.txt";
+    let body = b"source-if-match fail test";
+    let (bucket, _) = setup_bucket_with_object(&helper, src_key, body).await;
+
+    let src = format!("s3://{}/{}", bucket, src_key);
+    let dst = format!("s3://{}/{}", bucket, dst_key);
+
+    let output = run_s7cmd(&[
+        "rename",
+        "--source-profile",
+        PROFILE_NAME,
+        "--source-if-match",
+        "\"aaaabbbbccccdddd0000111122223333\"",
+        &src,
+        &dst,
+    ]);
+
+    assert_ne!(
+        output.status.code(),
+        Some(EXIT_CODE_SUCCESS),
+        "rename with wrong --source-if-match must not succeed; stdout={}, stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+    assert!(
+        helper.is_object_exist(&bucket, src_key, None).await,
+        "source must remain after precondition failure"
+    );
+    assert!(
+        !helper.is_object_exist(&bucket, dst_key, None).await,
+        "destination must not be created after precondition failure"
+    );
+
+    helper.delete_directory_bucket_with_cascade(&bucket).await;
+}
+
+// ---------------------------------------------------------------
+// Conditional checks — source-if-none-match (1 test)
+// ---------------------------------------------------------------
+
+/// `--source-if-none-match` always sends `*` internally. Because the
+/// source object exists, the condition "none match" is false and the API
+/// returns a 412 precondition failure. The source must remain intact.
+#[tokio::test]
+async fn rename_source_if_none_match_existing_object_fails() {
+    let helper = TestHelper::new().await;
+    let src_key = "sinm_src.txt";
+    let dst_key = "sinm_dst.txt";
+    let body = b"source-if-none-match test";
+    let (bucket, _) = setup_bucket_with_object(&helper, src_key, body).await;
+
+    let src = format!("s3://{}/{}", bucket, src_key);
+    let dst = format!("s3://{}/{}", bucket, dst_key);
+
+    let output = run_s7cmd(&[
+        "rename",
+        "--source-profile",
+        PROFILE_NAME,
+        "--source-if-none-match",
+        &src,
+        &dst,
+    ]);
+
+    assert_ne!(
+        output.status.code(),
+        Some(EXIT_CODE_SUCCESS),
+        "rename with --source-if-none-match on existing object must not succeed; stdout={}, stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+    assert!(
+        helper.is_object_exist(&bucket, src_key, None).await,
+        "source must remain after precondition failure"
+    );
+
+    helper.delete_directory_bucket_with_cascade(&bucket).await;
+}
+
+// ---------------------------------------------------------------
+// Conditional checks — target-if-none-match (2 tests)
+// ---------------------------------------------------------------
+
+/// `--target-if-none-match` always sends `*` internally. When the
+/// destination does not exist, the condition "none match any ETag" is
+/// true, so the rename succeeds.
+#[tokio::test]
+async fn rename_target_if_none_match_destination_absent_succeeds() {
+    let helper = TestHelper::new().await;
+    let src_key = "tinm_src.txt";
+    let dst_key = "tinm_dst_absent.txt";
+    let body = b"target-if-none-match absent test";
+    let (bucket, _) = setup_bucket_with_object(&helper, src_key, body).await;
+
+    let src = format!("s3://{}/{}", bucket, src_key);
+    let dst = format!("s3://{}/{}", bucket, dst_key);
+
+    let output = run_s7cmd(&[
+        "rename",
+        "--source-profile",
+        PROFILE_NAME,
+        "--target-if-none-match",
+        &src,
+        &dst,
+    ]);
+
+    assert_eq!(
+        output.status.code(),
+        Some(EXIT_CODE_SUCCESS),
+        "rename with --target-if-none-match on absent destination must succeed; stdout={}, stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+    assert!(helper.is_object_exist(&bucket, dst_key, None).await);
+    assert!(!helper.is_object_exist(&bucket, src_key, None).await);
+
+    helper.delete_directory_bucket_with_cascade(&bucket).await;
+}
+
+/// `--target-if-none-match` always sends `*` internally. When the
+/// destination already exists, the condition is false and the API
+/// returns 412. Source and destination must remain unchanged.
+#[tokio::test]
+async fn rename_target_if_none_match_destination_present_fails() {
+    let helper = TestHelper::new().await;
+    let src_key = "tinm_src2.txt";
+    let dst_key = "tinm_dst_present.txt";
+    let src_body = b"source body";
+    let dst_body = b"pre-existing destination body";
+    let (bucket, _) = setup_bucket_with_object(&helper, src_key, src_body).await;
+    helper.put_object(&bucket, dst_key, dst_body.to_vec()).await;
+
+    let src = format!("s3://{}/{}", bucket, src_key);
+    let dst = format!("s3://{}/{}", bucket, dst_key);
+
+    let output = run_s7cmd(&[
+        "rename",
+        "--source-profile",
+        PROFILE_NAME,
+        "--target-if-none-match",
+        &src,
+        &dst,
+    ]);
+
+    assert_ne!(
+        output.status.code(),
+        Some(EXIT_CODE_SUCCESS),
+        "rename with --target-if-none-match on present destination must not succeed; stdout={}, stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+    assert!(
+        helper.is_object_exist(&bucket, src_key, None).await,
+        "source must remain"
+    );
+    let dst_bytes = helper.get_object_bytes(&bucket, dst_key, None).await;
+    assert_eq!(dst_bytes, dst_body, "destination content must be unchanged");
+
+    helper.delete_directory_bucket_with_cascade(&bucket).await;
+}
+
+// ---------------------------------------------------------------
+// Conditional checks — target-if-match (2 tests)
+// ---------------------------------------------------------------
+
+/// `--target-if-match <correct ETag>` with a pre-existing destination
+/// whose ETag matches must overwrite the destination and succeed.
+#[tokio::test]
+async fn rename_target_if_match_correct_etag_succeeds() {
+    let helper = TestHelper::new().await;
+    let src_key = "tim_src.txt";
+    let dst_key = "tim_dst.txt";
+    let src_body = b"source for target-if-match";
+    let dst_body = b"existing destination";
+    let (bucket, _) = setup_bucket_with_object(&helper, src_key, src_body).await;
+    helper.put_object(&bucket, dst_key, dst_body.to_vec()).await;
+    let dst_head = helper.head_object(&bucket, dst_key, None).await;
+    let dst_etag = dst_head.e_tag().unwrap().to_string();
+
+    let src = format!("s3://{}/{}", bucket, src_key);
+    let dst = format!("s3://{}/{}", bucket, dst_key);
+
+    let output = run_s7cmd(&[
+        "rename",
+        "--source-profile",
+        PROFILE_NAME,
+        "--target-if-match",
+        &dst_etag,
+        &src,
+        &dst,
+    ]);
+
+    assert_eq!(
+        output.status.code(),
+        Some(EXIT_CODE_SUCCESS),
+        "rename with correct --target-if-match must exit 0; stdout={}, stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+    assert!(!helper.is_object_exist(&bucket, src_key, None).await);
+    let new_dst_bytes = helper.get_object_bytes(&bucket, dst_key, None).await;
+    assert_eq!(
+        new_dst_bytes, src_body,
+        "destination must now contain source content"
+    );
+
+    helper.delete_directory_bucket_with_cascade(&bucket).await;
+}
+
+/// `--target-if-match <wrong ETag>` must fail (412) and leave both
+/// source and destination unchanged.
+#[tokio::test]
+async fn rename_target_if_match_wrong_etag_fails() {
+    let helper = TestHelper::new().await;
+    let src_key = "tim_fail_src.txt";
+    let dst_key = "tim_fail_dst.txt";
+    let src_body = b"source for target-if-match failure";
+    let dst_body = b"existing destination unchanged";
+    let (bucket, _) = setup_bucket_with_object(&helper, src_key, src_body).await;
+    helper.put_object(&bucket, dst_key, dst_body.to_vec()).await;
+
+    let src = format!("s3://{}/{}", bucket, src_key);
+    let dst = format!("s3://{}/{}", bucket, dst_key);
+
+    let output = run_s7cmd(&[
+        "rename",
+        "--source-profile",
+        PROFILE_NAME,
+        "--target-if-match",
+        "\"aaaabbbbccccdddd0000111122223333\"",
+        &src,
+        &dst,
+    ]);
+
+    assert_ne!(
+        output.status.code(),
+        Some(EXIT_CODE_SUCCESS),
+        "rename with wrong --target-if-match must not succeed; stdout={}, stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+    assert!(
+        helper.is_object_exist(&bucket, src_key, None).await,
+        "source must remain"
+    );
+    let dst_bytes = helper.get_object_bytes(&bucket, dst_key, None).await;
+    assert_eq!(dst_bytes, dst_body, "destination content must be unchanged");
+
+    helper.delete_directory_bucket_with_cascade(&bucket).await;
+}
+
+// ---------------------------------------------------------------
+// Special characters in key (1 test)
+// ---------------------------------------------------------------
+
+/// Rename with spaces, slashes, and Unicode characters in the key name.
+/// The CLI must percent-encode them correctly when building the
+/// `rename_source` header.
+#[tokio::test]
+async fn rename_special_characters_in_key() {
+    let helper = TestHelper::new().await;
+    let src_key = "dir/file with spaces & unicode \u{00e9}.txt";
+    let dst_key = "dir/renamed \u{00e9} file.txt";
+    let body = b"special chars rename body";
+    let (bucket, _) = setup_bucket_with_object(&helper, src_key, body).await;
+
+    let src = format!("s3://{}/{}", bucket, src_key);
+    let dst = format!("s3://{}/{}", bucket, dst_key);
+
+    let output = run_s7cmd(&["rename", "--source-profile", PROFILE_NAME, &src, &dst]);
+
+    assert_eq!(
+        output.status.code(),
+        Some(EXIT_CODE_SUCCESS),
+        "rename with special-character keys must exit 0; stdout={}, stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+    assert!(!helper.is_object_exist(&bucket, src_key, None).await);
+    assert!(helper.is_object_exist(&bucket, dst_key, None).await);
+
+    helper.delete_directory_bucket_with_cascade(&bucket).await;
+}
+
+// ---------------------------------------------------------------
+// CLI validation — no AWS contact (2 tests)
+// ---------------------------------------------------------------
+
+/// Non-Express-One-Zone bucket name (does not end with `--<az>--x-s3`)
+/// must be rejected by `validate()` before any AWS call, exiting 2.
+#[tokio::test]
+async fn rename_non_express_onezone_bucket_exits_2() {
+    let output = run_s7cmd(&[
+        "rename",
+        "--source-profile",
+        PROFILE_NAME,
+        "s3://my-regular-bucket/source.txt",
+        "s3://my-regular-bucket/destination.txt",
+    ]);
+
+    assert_eq!(
+        output.status.code(),
+        Some(EXIT_CODE_CLAP_ARG_ERROR),
+        "rename to non-Express-One-Zone bucket must exit 2; stdout={}, stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+}
+
+/// Source and destination in different buckets must be rejected by
+/// `validate()` before any AWS call, exiting 2.
+#[tokio::test]
+async fn rename_different_buckets_exits_2() {
+    let output = run_s7cmd(&[
+        "rename",
+        "--source-profile",
+        PROFILE_NAME,
+        "s3://bucket-a--apne1-az4--x-s3/source.txt",
+        "s3://bucket-b--apne1-az4--x-s3/destination.txt",
+    ]);
+
+    assert_eq!(
+        output.status.code(),
+        Some(EXIT_CODE_CLAP_ARG_ERROR),
+        "rename across different buckets must exit 2; stdout={}, stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+}


### PR DESCRIPTION
- Updated `aws-sdk-s3` to 1.133 for enhanced features and fixes.
- Upgraded dependencies for security and functionality, including `shlex` to 2.0.1 and `ureq` to 3.
- Added new library dependencies (`pem-rfc7468`, `primeorder`, etc.) and removed deprecated ones.
- Adjusted Cargo.lock to reflect library upgrades and their respective checksum changes.

## Contributing

- Bug reports are welcome, but responses are not guaranteed.
- Since this project is considered functionally complete, I will not accept any feature requests.
- If you find this project useful, feel free to fork and modify it as you wish.

🔒 I consider this project “complete” and will maintain it only minimally going forward.
However, I intend to keep the AWS SDK for Rust and other dependencies up to date monthly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a top-level "rename" command to perform atomic server-side renames within Express One Zone buckets, with dry-run and conditional-match options.
* **Documentation**
  * CLI help and README updated to document the new rename subcommand and option groups.
* **Tests**
  * Added unit and gated end-to-end tests covering rename behavior, validation rules, conditional flags, dry-run output, and edge cases.
* **Chores**
  * Bumped package version and updated pinned dependencies.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nidor1998/s7cmd/pull/15?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->