### PR TITLE
feat: apply s3util-rs 1.7.1 (account-regional create-bucket, get-obje…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,40 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.5.0] - 2026-07-11
+
+### Added
+
+#### s3util-rs
+
+- `create-bucket` gains account-level regional bucket support: pass `--bucket-namespace account-regional` together with
+  `--create-bucket-configuration LocationConstraint=<region>` to create a bucket in your account's regional namespace
+  (name shape `<prefix>-<accountid>-<region>-an`). The two options are required together — `account-regional` is the
+  only accepted `--bucket-namespace` value and `LocationConstraint=<region>` the only accepted
+  `--create-bucket-configuration` value — and when both are supplied they are sent to `CreateBucket` verbatim, bypassing
+  the region/name-derived configuration.
+
+### Fixed
+
+#### s3util-rs
+
+- `get-object-annotation`: an object whose additional checksum uses an algorithm s3util cannot recompute (e.g. `SHA512`,
+  `MD5`, `XXHASH*`) now fails with a clear integrity error instead of panicking. The unsupported algorithm is detected
+  up front and rejected rather than reaching the checksum constructor.
+
+### Changed
+
+- s3util-rs `v1.6.0 -> v1.7.1`
+
+### Underlying libraries
+
+```toml
+s3sync = "=1.59.0"
+s3util-rs = "=1.7.1"
+s3rm-rs = "=1.3.8"
+s3ls-rs = "=1.0.3"
+```
+
 ## [1.4.0] - 2026-07-05
 
 Adds S3 object-annotation support.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `MD5`, `XXHASH*`) now fails with a clear integrity error instead of panicking. The unsupported algorithm is detected
   up front and rejected rather than reaching the checksum constructor.
 
+### Security
+
+- Bump `crossbeam-epoch` `v0.9.18 -> v0.9.20` to address [RUSTSEC-2026-0204](https://rustsec.org/advisories/RUSTSEC-2026-0204).
+  Transitive dependency (pulled in via `s3ls-rs` → `rayon`); `Cargo.lock`-only, with no public API or behavior change.
+
 ### Changed
 
 - s3util-rs `v1.6.0 -> v1.7.1`

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1063,9 +1063,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3006,9 +3006,9 @@ dependencies = [
 
 [[package]]
 name = "s3util-rs"
-version = "1.6.0"
+version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc297f58d1637860fd571944665ab38ad72273e2e99f3c65e600608c544ab964"
+checksum = "82e5511aaf9c2914fb38558689b3190cff2481b3f7d1785865ec5d74325738b6"
 dependencies = [
  "anyhow",
  "async-channel",
@@ -3065,7 +3065,7 @@ dependencies = [
 
 [[package]]
 name = "s7cmd"
-version = "1.4.0"
+version = "1.5.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "s7cmd"
-version = "1.4.0"
+version = "1.5.0"
 edition = "2024"
 rust-version = "1.91.1"
 license = "Apache-2.0"
@@ -17,7 +17,7 @@ categories = ["command-line-utilities", "filesystem"]
 # (--filter-callback-lua-script, etc.) automatically appear under
 # `s7cmd sync --help`. Use default-features = false to opt out.
 s3sync     = "=1.59.0"
-s3util-rs  = "=1.6.0"
+s3util-rs  = "=1.7.1"
 # Vendored bin code is sourced from these versions; pin minor.
 s3rm-rs    = "=1.3.8"
 s3ls-rs    = "=1.0.3"
@@ -66,7 +66,7 @@ dyn-clone    = "1.0"
 serde_json   = "1"
 # Used by the vendored get-object-annotation runner to write the downloaded
 # payload to a temp file and atomically rename it into place. Pinned to the
-# same minor s3util-rs 1.6.0 vendors so the dep tree stays unified.
+# same minor s3util-rs 1.7.1 vendors so the dep tree stays unified.
 tempfile     = "3"
 
 [features]
@@ -83,7 +83,7 @@ uuid = { version = "1", features = ["v4"] }
 # tempfile is a regular dependency (see [dependencies]); it is therefore also
 # available to tests without a separate dev-dependency entry.
 # Used by the vendored get_object_annotation.rs unit tests to recompute the
-# MD5 an AES256 object's ETag encodes. Same minor s3util-rs 1.6.0 vendors.
+# MD5 an AES256 object's ETag encodes. Same minor s3util-rs 1.7.1 vendors.
 md5 = "0.8"
 # Used by mv.rs unit tests to implement a fake `StorageTrait` for the
 # source-delete decision tree. Already a transitive dep via s3util-rs;

--- a/src/util_bin/cli/create_bucket.rs
+++ b/src/util_bin/cli/create_bucket.rs
@@ -1,11 +1,11 @@
-// Vendored from s3util-rs@1.2.0
+// Vendored from s3util-rs@1.7.1
 //   src/bin/s3util/cli/create_bucket.rs
-// Adjustments: no tests stripped; rewrote crate::cli → super
+// Adjustments: none — the upstream file already targets `super::ExitStatus`.
 
 use anyhow::Result;
 use tracing::info;
 
-use aws_sdk_s3::types::Tagging;
+use aws_sdk_s3::types::{BucketNamespace, Tagging};
 use s3util_rs::config::ClientConfig;
 use s3util_rs::config::args::create_bucket::CreateBucketArgs;
 use s3util_rs::storage::s3::api::{self, HeadError};
@@ -36,6 +36,12 @@ pub async fn run_create_bucket(
         None
     };
 
+    // Account-regional bucket options. Both flags are validated by clap's
+    // value_parsers and clap enforces that they are supplied together, so the
+    // location constraint is present exactly when the namespace is.
+    let bucket_namespace = args.bucket_namespace.as_deref().map(BucketNamespace::from);
+    let location_constraint = args.create_bucket_configuration.as_deref();
+
     let client = client_config.create_client().await;
 
     if args.if_not_exists {
@@ -57,13 +63,21 @@ pub async fn run_create_bucket(
 
     if args.dry_run {
         info!(bucket = %bucket, "[dry-run] would create bucket.");
+        if let Some(bucket_namespace) = args.bucket_namespace.as_deref() {
+            info!(
+                bucket = %bucket,
+                bucket_namespace,
+                location_constraint = location_constraint.unwrap_or_default(),
+                "[dry-run] would use account-regional bucket namespace."
+            );
+        }
         if tagging.is_some() {
             info!(bucket = %bucket, "[dry-run] would put bucket tagging.");
         }
         return Ok(ExitStatus::Success);
     }
 
-    api::create_bucket(&client, &bucket).await?;
+    api::create_bucket(&client, &bucket, bucket_namespace, location_constraint).await?;
     info!(bucket = %bucket, "Bucket created.");
 
     if let Some(tagging) = tagging {

--- a/src/util_bin/cli/get_object_annotation.rs
+++ b/src/util_bin/cli/get_object_annotation.rs
@@ -1,8 +1,12 @@
-// Vendored from s3util-rs@1.6.0
+// Vendored from s3util-rs@1.7.1
 //   src/bin/s3util/cli/get_object_annotation.rs
-// Adjustments: added the verify_saved_file_err_when_file_unreadable unit
-//              test; otherwise none — the upstream file already targets
-//              `super::ExitStatus`.
+// Adjustments: local verify-before-rename output path — write_verified_output
+//              writes to a temp file, re-verifies its on-disk bytes, and only
+//              then atomically renames onto <OUTFILE> (upstream renames first,
+//              then verifies), plus the accompanying write_verified_output_*
+//              and verify_saved_file_err_when_file_unreadable unit tests. The
+//              detect_checksum / check_integrity unsupported-algorithm handling
+//              tracks upstream 1.7.0.
 
 use std::io::Write as _;
 use std::path::Path;
@@ -17,13 +21,19 @@ use s3util_rs::config::ClientConfig;
 use s3util_rs::config::args::get_object_annotation::GetObjectAnnotationArgs;
 use s3util_rs::output::json::get_object_annotation_to_json;
 use s3util_rs::storage::annotation;
+use s3util_rs::storage::checksum::AdditionalChecksum;
 use s3util_rs::storage::s3::api::{self, GetObjectAnnotationParams, ObjectAnnotationError};
 
 use super::ExitStatus;
 
-/// Pick the single additional checksum S3 returned, mapped to the algorithm we
-/// can recompute locally. Returns `None` when no supported checksum is present.
+/// Pick the single additional checksum S3 returned. Algorithms s3util can
+/// recompute locally are preferred; if only an algorithm s3util cannot verify
+/// (e.g. SHA512, MD5, or the XXHASH family) is present, it is still returned so
+/// the caller can treat it as an integrity error rather than silently skipping
+/// verification or panicking. Returns `None` when no additional checksum is
+/// present.
 fn detect_checksum(out: &GetObjectAnnotationOutput) -> Option<(ChecksumAlgorithm, String)> {
+    // Supported algorithms first (s3util can recompute these).
     if let Some(v) = out.checksum_crc64_nvme() {
         return Some((ChecksumAlgorithm::Crc64Nvme, v.to_string()));
     }
@@ -38,6 +48,24 @@ fn detect_checksum(out: &GetObjectAnnotationOutput) -> Option<(ChecksumAlgorithm
     }
     if let Some(v) = out.checksum_sha256() {
         return Some((ChecksumAlgorithm::Sha256, v.to_string()));
+    }
+    // Algorithms S3 can return that s3util cannot recompute — surfaced (not
+    // ignored) so `check_integrity` rejects them instead of writing unverified
+    // data or panicking in `AdditionalChecksum::new`.
+    if let Some(v) = out.checksum_sha512() {
+        return Some((ChecksumAlgorithm::Sha512, v.to_string()));
+    }
+    if let Some(v) = out.checksum_md5() {
+        return Some((ChecksumAlgorithm::Md5, v.to_string()));
+    }
+    if let Some(v) = out.checksum_xxhash64() {
+        return Some((ChecksumAlgorithm::Xxhash64, v.to_string()));
+    }
+    if let Some(v) = out.checksum_xxhash3() {
+        return Some((ChecksumAlgorithm::Xxhash3, v.to_string()));
+    }
+    if let Some(v) = out.checksum_xxhash128() {
+        return Some((ChecksumAlgorithm::Xxhash128, v.to_string()));
     }
     None
 }
@@ -82,6 +110,15 @@ fn check_integrity(
         None => {}
     }
     if let Some((algo, expected)) = checksum {
+        // Reject algorithms s3util cannot recompute (e.g. SHA512) up front:
+        // verifying them would panic in `AdditionalChecksum::new`, so treat an
+        // unsupported checksum as an integrity error instead.
+        if !AdditionalChecksum::is_supported(algo) {
+            anyhow::bail!(
+                "s3://{bucket}/{key} carries a {} checksum, which s3util cannot verify",
+                algo.as_str()
+            );
+        }
         if annotation::verify_additional_checksum(bytes, algo.clone(), expected) {
             verified = true;
         } else {
@@ -461,6 +498,67 @@ mod tests {
         assert_eq!(val, "crc32val");
     }
 
+    // Every additional checksum S3 can return that s3util cannot recompute must
+    // be surfaced (not ignored), so the integrity check can reject it instead of
+    // silently skipping verification or panicking.
+    #[test]
+    fn detect_checksum_surfaces_every_unsupported_algorithm() {
+        let cases = [
+            (
+                GetObjectAnnotationOutput::builder()
+                    .annotation_payload(empty_payload())
+                    .checksum_sha512("v")
+                    .build(),
+                ChecksumAlgorithm::Sha512,
+            ),
+            (
+                GetObjectAnnotationOutput::builder()
+                    .annotation_payload(empty_payload())
+                    .checksum_md5("v")
+                    .build(),
+                ChecksumAlgorithm::Md5,
+            ),
+            (
+                GetObjectAnnotationOutput::builder()
+                    .annotation_payload(empty_payload())
+                    .checksum_xxhash64("v")
+                    .build(),
+                ChecksumAlgorithm::Xxhash64,
+            ),
+            (
+                GetObjectAnnotationOutput::builder()
+                    .annotation_payload(empty_payload())
+                    .checksum_xxhash3("v")
+                    .build(),
+                ChecksumAlgorithm::Xxhash3,
+            ),
+            (
+                GetObjectAnnotationOutput::builder()
+                    .annotation_payload(empty_payload())
+                    .checksum_xxhash128("v")
+                    .build(),
+                ChecksumAlgorithm::Xxhash128,
+            ),
+        ];
+        for (out, expected) in cases {
+            let (algo, val) = detect_checksum(&out).expect("checksum present");
+            assert_eq!(algo, expected, "unexpected algorithm for {expected:?}");
+            assert_eq!(val, "v");
+        }
+    }
+
+    // A supported checksum still wins when an unsupported one is also present.
+    #[test]
+    fn detect_checksum_prefers_supported_over_unsupported() {
+        let out = GetObjectAnnotationOutput::builder()
+            .annotation_payload(empty_payload())
+            .checksum_sha256("sha256val")
+            .checksum_sha512("sha512val")
+            .build();
+        let (algo, _) = detect_checksum(&out).expect("checksum present");
+        assert_eq!(algo, ChecksumAlgorithm::Sha256);
+    }
+
     #[test]
     fn check_integrity_verified_on_matching_checksum() {
         let payload = b"hello world";
@@ -502,6 +600,27 @@ mod tests {
     fn check_integrity_unverifiable_when_nothing_applies() {
         let res = check_integrity(b"hello", Some(5), None, None, None, "b", "k").unwrap();
         assert!(matches!(res, IntegrityCheck::Unverifiable));
+    }
+
+    #[test]
+    fn check_integrity_err_on_every_unsupported_checksum() {
+        // Every algorithm s3util cannot recompute must return a clean error
+        // rather than panic in `AdditionalChecksum::new`.
+        for algo in [
+            ChecksumAlgorithm::Sha512,
+            ChecksumAlgorithm::Md5,
+            ChecksumAlgorithm::Xxhash64,
+            ChecksumAlgorithm::Xxhash3,
+            ChecksumAlgorithm::Xxhash128,
+        ] {
+            let checksum = (algo.clone(), "anybase64value".to_string());
+            let err =
+                check_integrity(b"hello", None, None, None, Some(&checksum), "b", "k").unwrap_err();
+            assert!(
+                format!("{err:#}").contains("s3util cannot verify"),
+                "{algo:?}: unexpected error: {err:#}"
+            );
+        }
     }
 
     #[test]
@@ -686,6 +805,36 @@ mod tests {
             std::fs::read_dir(dir.path()).unwrap().count(),
             1,
             "temp file must be renamed onto the outfile, not left behind"
+        );
+    }
+
+    #[test]
+    fn write_verified_output_err_when_temp_file_cannot_be_created() {
+        // The <OUTFILE>'s parent directory does not exist, so the temp file
+        // cannot be created next to it. write_verified_output must surface a
+        // clean error naming the file rather than write anything — covering the
+        // `NamedTempFile::new_in` failure arm.
+        let dir = tempfile::tempdir().unwrap();
+        let outfile = dir.path().join("no-such-subdir").join("out.bin");
+        let payload = b"payload bytes";
+        let err = write_verified_output(
+            outfile.to_str().unwrap(),
+            payload,
+            Some(payload.len() as i64),
+            None,
+            None,
+            None,
+            "b",
+            "k",
+        )
+        .unwrap_err();
+        assert!(
+            format!("{err:#}").contains("creating temp file next to"),
+            "got: {err:#}"
+        );
+        assert!(
+            !outfile.exists(),
+            "no file may be created when the temp write fails"
         );
     }
 }

--- a/tests/cli_create_bucket.rs
+++ b/tests/cli_create_bucket.rs
@@ -58,11 +58,110 @@ fn help_mentions_if_not_exists_option() {
 }
 
 #[test]
+fn help_mentions_bucket_namespace_and_configuration_options() {
+    let (ok, stdout, _stderr, _code) = run(s7cmd().args(["create-bucket", "--help"]));
+    assert!(ok);
+    assert!(
+        stdout.contains("--bucket-namespace"),
+        "expected --bucket-namespace in help output: {stdout}"
+    );
+    assert!(
+        stdout.contains("--create-bucket-configuration"),
+        "expected --create-bucket-configuration in help output: {stdout}"
+    );
+}
+
+// The account-regional flags are a both-or-neither pair (clap `requires`).
+#[test]
+fn bucket_namespace_without_configuration_exits_2() {
+    let (ok, _stdout, stderr, code) = run(s7cmd().args([
+        "create-bucket",
+        "s3://my-bucket",
+        "--bucket-namespace",
+        "account-regional",
+    ]));
+    assert!(!ok);
+    assert_eq!(code, Some(2), "clap missing-requirement should exit 2");
+    assert!(
+        stderr.to_lowercase().contains("required")
+            || stderr.contains("--create-bucket-configuration"),
+        "expected a missing --create-bucket-configuration message; got: {stderr}"
+    );
+}
+
+#[test]
+fn configuration_without_bucket_namespace_exits_2() {
+    let (ok, _stdout, stderr, code) = run(s7cmd().args([
+        "create-bucket",
+        "s3://my-bucket",
+        "--create-bucket-configuration",
+        "LocationConstraint=ap-northeast-1",
+    ]));
+    assert!(!ok);
+    assert_eq!(code, Some(2), "clap missing-requirement should exit 2");
+    assert!(
+        stderr.to_lowercase().contains("required") || stderr.contains("--bucket-namespace"),
+        "expected a missing --bucket-namespace message; got: {stderr}"
+    );
+}
+
+// Only `account-regional` is accepted for --bucket-namespace (value_parser).
+#[test]
+fn invalid_bucket_namespace_value_rejected() {
+    let (ok, _stdout, stderr, _code) = run(s7cmd().args([
+        "create-bucket",
+        "s3://my-bucket",
+        "--bucket-namespace",
+        "global",
+        "--create-bucket-configuration",
+        "LocationConstraint=ap-northeast-1",
+    ]));
+    assert!(
+        !ok,
+        "only account-regional is accepted for --bucket-namespace"
+    );
+    assert!(!stderr.is_empty());
+}
+
+// Only `LocationConstraint=<region>` is accepted for --create-bucket-configuration.
+#[test]
+fn invalid_create_bucket_configuration_value_rejected() {
+    let (ok, _stdout, stderr, _code) = run(s7cmd().args([
+        "create-bucket",
+        "s3://my-bucket",
+        "--bucket-namespace",
+        "account-regional",
+        "--create-bucket-configuration",
+        "LocationType=AvailabilityZone",
+    ]));
+    assert!(
+        !ok,
+        "only LocationConstraint= is accepted for --create-bucket-configuration"
+    );
+    assert!(!stderr.is_empty());
+}
+
+#[test]
 fn missing_target_exits_non_zero() {
     let (ok, _stdout, stderr, code) = run(s7cmd().arg("create-bucket"));
     assert!(!ok);
     assert_eq!(code, Some(2), "clap missing-arg should exit 2");
     assert!(stderr.to_lowercase().contains("required") || stderr.to_lowercase().contains("usage"));
+}
+
+#[test]
+fn target_with_key_in_path_exits_1() {
+    // A create-bucket target must be s3://<BUCKET> with no key/prefix. A path
+    // carrying a key is accepted by clap but rejected by bucket_name() before
+    // any AWS call, so the runner returns Err (exit 1). Covers the bucket_name()
+    // error arm in run_create_bucket.
+    let (ok, _stdout, stderr, code) = run(s7cmd().args(["create-bucket", "s3://bucket/key"]));
+    assert!(!ok);
+    assert_eq!(code, Some(1), "invalid target (has key) should exit 1");
+    assert!(
+        stderr.contains("with no key or prefix"),
+        "expected the no-key/prefix error; got: {stderr}"
+    );
 }
 
 // NOTE: s3util-rs has a `auto_complete_shell_short_circuits_without_target`

--- a/tests/cli_dry_run.rs
+++ b/tests/cli_dry_run.rs
@@ -191,6 +191,33 @@ fn create_bucket_dry_run_with_tagging_logs_both_lines() {
     );
 }
 
+#[test]
+fn create_bucket_dry_run_account_regional_logs_namespace_line() {
+    let (ok, _stdout, stderr, code) = run(s7cmd().args([
+        "create-bucket",
+        "--dry-run",
+        "--bucket-namespace",
+        "account-regional",
+        "--create-bucket-configuration",
+        "LocationConstraint=ap-northeast-1",
+        FAKE_BUCKET,
+    ]));
+    assert!(ok, "create-bucket --dry-run must exit 0; stderr={stderr}");
+    assert_eq!(code, Some(0));
+    assert!(
+        stderr.contains("would create bucket"),
+        "missing 'would create bucket': {stderr}"
+    );
+    assert!(
+        stderr.contains("account-regional bucket namespace"),
+        "missing account-regional namespace dry-run line: {stderr}"
+    );
+    assert!(
+        stderr.contains("ap-northeast-1"),
+        "expected the location constraint in the dry-run line: {stderr}"
+    );
+}
+
 // ---------- put-* (representative: put-bucket-cors with JSON config) ----------
 
 #[test]

--- a/tests/cli_get_object_annotation.rs
+++ b/tests/cli_get_object_annotation.rs
@@ -384,3 +384,39 @@ fn mock_endpoint_aes256_etag_mismatch_exits_1_without_outfile() {
     );
     assert!(!outfile.exists(), "no outfile may be created on mismatch");
 }
+
+#[test]
+fn mock_endpoint_write_to_unwritable_outfile_exits_1_without_outfile() {
+    // The S3 fetch succeeds and the payload passes the in-transit checks
+    // (unverifiable, but writable), yet the <OUTFILE>'s parent directory does
+    // not exist so the temp-file write fails. run_get_object_annotation must
+    // propagate that as exit 1 and create nothing — covering the
+    // write_verified_output error branch reached only after a successful fetch.
+    let dir = tempfile::tempdir().unwrap();
+    let missing_parent = dir.path().join("no-such-subdir");
+    let outfile = missing_parent.join("annotation.bin");
+    let payload = "mock annotation payload";
+    let server = MockS3Server::start(vec![MockResponse::new(200, payload)]);
+    let mut cmd = s7cmd_cmd_clean_env();
+    cmd.args(["get-object-annotation", "--annotation-name", "note"])
+        .args(mock_target_args(&server.endpoint_url()))
+        .args(["s3://mock-bucket/mock-key", outfile.to_str().unwrap()]);
+    let (code, _stdout, stderr) = common::run(&mut cmd);
+    assert_eq!(
+        code,
+        Some(1),
+        "an unwritable outfile must exit 1; stderr: {stderr}"
+    );
+    assert!(
+        stderr.contains("creating temp file next to"),
+        "expected the temp-file creation error; got: {stderr}"
+    );
+    assert!(
+        !outfile.exists(),
+        "no outfile may be created on write failure"
+    );
+    assert!(
+        !missing_parent.exists(),
+        "the missing parent dir must not be created"
+    );
+}

--- a/tests/e2e_bucket_ops.rs
+++ b/tests/e2e_bucket_ops.rs
@@ -63,6 +63,109 @@ async fn create_bucket_dispatch_with_tagging() {
     helper.delete_bucket_with_cascade(&bucket).await;
 }
 
+// ---- create-bucket --bucket-namespace account-regional (s3util-rs 1.7.0) ----
+
+/// create-bucket + head-bucket + delete-bucket round-trip for an account-level
+/// regional bucket (`--bucket-namespace account-regional`).
+///
+/// Account-regional buckets are named `<prefix>-<accountid>-<region>-an` and
+/// require the account to be enrolled in the account-regional namespace. The
+/// account id and location constraint are read from the environment so the test
+/// can target any enrolled account/region without hardcoding them:
+///
+///   * `S7CMD_E2E_ACCOUNT_ID`          — 12-digit AWS account id (required; the
+///     test is skipped when unset).
+///   * `S7CMD_E2E_LOCATION_CONSTRAINT` — region for the LocationConstraint and
+///     the `--target-region` (optional; defaults to `REGION`).
+///
+/// Exercises the explicit-configuration branch of create-bucket end-to-end:
+/// `--bucket-namespace account-regional` together with
+/// `--create-bucket-configuration LocationConstraint=<region>`, which are sent
+/// to `CreateBucket` verbatim, bypassing the region/name-derived configuration.
+#[tokio::test]
+async fn create_and_delete_account_regional_bucket_round_trip() {
+    let Ok(account_id) = std::env::var("S7CMD_E2E_ACCOUNT_ID") else {
+        eprintln!(
+            "skipping create_and_delete_account_regional_bucket_round_trip: \
+             S7CMD_E2E_ACCOUNT_ID is not set"
+        );
+        return;
+    };
+    let region =
+        std::env::var("S7CMD_E2E_LOCATION_CONSTRAINT").unwrap_or_else(|_| REGION.to_string());
+
+    // Account-regional name: <prefix>-<accountid>-<region>-an. Keep the prefix
+    // short so the full name stays within the 63-char limit.
+    let prefix = format!(
+        "s7cmd-e2e-{}",
+        &uuid::Uuid::new_v4().simple().to_string()[..8]
+    );
+    let bucket = format!("{prefix}-{account_id}-{region}-an");
+    let target = format!("s3://{bucket}");
+    let create_bucket_configuration = format!("LocationConstraint={region}");
+
+    let (create_code, create_stdout, create_stderr) = run(s7cmd_cmd().args([
+        "create-bucket",
+        "--target-profile",
+        "s7cmd-e2e-test",
+        "--target-region",
+        &region,
+        "--bucket-namespace",
+        "account-regional",
+        "--create-bucket-configuration",
+        &create_bucket_configuration,
+        &target,
+    ]));
+
+    if create_code != Some(0) {
+        // Best-effort cleanup in case the bucket was partially created.
+        let _ = run(s7cmd_cmd().args([
+            "delete-bucket",
+            "--target-profile",
+            "s7cmd-e2e-test",
+            "--target-region",
+            &region,
+            &target,
+        ]));
+        panic!(
+            "create-bucket (account-regional) must exit 0; stdout={create_stdout}\nstderr={create_stderr}"
+        );
+    }
+
+    // The bucket is addressed by its full account-regional name; head-bucket in
+    // the same region must report it as existing.
+    let (head_code, _head_stdout, head_stderr) = run(s7cmd_cmd().args([
+        "head-bucket",
+        "--target-profile",
+        "s7cmd-e2e-test",
+        "--target-region",
+        &region,
+        &target,
+    ]));
+
+    // Delete before asserting on head so the bucket is cleaned up even if the
+    // head assertion fails.
+    let (delete_code, _delete_stdout, delete_stderr) = run(s7cmd_cmd().args([
+        "delete-bucket",
+        "--target-profile",
+        "s7cmd-e2e-test",
+        "--target-region",
+        &region,
+        &target,
+    ]));
+
+    assert_eq!(
+        head_code,
+        Some(0),
+        "head-bucket on the account-regional bucket must exit 0; stderr={head_stderr}"
+    );
+    assert_eq!(
+        delete_code,
+        Some(0),
+        "delete-bucket (account-regional) must exit 0; stderr={delete_stderr}"
+    );
+}
+
 // ---- create-bucket --if-not-exists (s3util-rs 1.2.0 idempotency flag) ----
 
 #[tokio::test]

--- a/tests/e2e_object_annotations.rs
+++ b/tests/e2e_object_annotations.rs
@@ -206,6 +206,70 @@ async fn get_object_annotation_dispatch_success_to_file() {
 }
 
 #[tokio::test]
+async fn get_object_annotation_dispatch_write_failure_exits_1() {
+    // The annotation is fetched successfully, but <OUTFILE>'s parent directory
+    // does not exist, so the temp-file write fails. get-object-annotation must
+    // exit 1 and create nothing — the end-to-end counterpart of the runner's
+    // write-failure path (verify-before-rename never creates a partial file).
+    let helper = TestHelper::new().await;
+    let bucket = generate_bucket_name();
+    helper.create_bucket(&bucket, REGION).await;
+    helper
+        .put_object(&bucket, "note.txt", b"object body".to_vec())
+        .await;
+
+    let dir = create_temp_dir();
+    let payload = b"hello annotation payload";
+    let payload_file = create_test_file(&dir, "payload.bin", payload);
+    // <OUTFILE> under a directory that does not exist: the write must fail.
+    let out_file = dir.join("no-such-subdir").join("got.bin");
+    let target = format!("s3://{bucket}/note.txt");
+
+    let (put_code, _o, put_err) = run(s7cmd_cmd().args([
+        "put-object-annotation",
+        "--target-profile",
+        PROFILE,
+        "--target-region",
+        REGION,
+        "--annotation-name",
+        ANNOTATION_NAME,
+        "--annotation-payload",
+        payload_file.to_str().unwrap(),
+        &target,
+    ]));
+    assert_eq!(put_code, Some(0), "seed put must exit 0; stderr={put_err}");
+
+    let (code, _stdout, stderr) = run(s7cmd_cmd().args([
+        "get-object-annotation",
+        "--target-profile",
+        PROFILE,
+        "--target-region",
+        REGION,
+        "--annotation-name",
+        ANNOTATION_NAME,
+        &target,
+        out_file.to_str().unwrap(),
+    ]));
+
+    assert_eq!(
+        code,
+        Some(1),
+        "get-object-annotation to an unwritable outfile must exit 1; stderr={stderr}"
+    );
+    assert!(
+        stderr.contains("creating temp file next to"),
+        "expected the temp-file creation error; got: {stderr}"
+    );
+    assert!(
+        !out_file.exists(),
+        "no outfile may be created on write failure"
+    );
+
+    helper.delete_bucket_with_cascade(&bucket).await;
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[tokio::test]
 async fn get_object_annotation_dispatch_success_to_stdout() {
     let helper = TestHelper::new().await;
     let bucket = generate_bucket_name();


### PR DESCRIPTION
…ct-annotation checksum fix)

Bump s3util-rs =1.6.0 -> =1.7.1 and re-sync the vendored runners.

- create-bucket: account-level regional bucket support. Passing --bucket-namespace account-regional together with --create-bucket-configuration LocationConstraint=<region> sends both to CreateBucket verbatim, bypassing the region/name-derived configuration. The vendored runner now matches upstream 1.7.1 byte-for-byte.
- get-object-annotation: an additional checksum in an algorithm s3util cannot recompute (SHA512, MD5, XXHASH*) now fails with a clear integrity error instead of panicking (detect_checksum surfaces it; check_integrity rejects it up front via AdditionalChecksum::is_supported). Applied on top of s7cmd's local verify-before-rename output path; detect_checksum/check_integrity match upstream 1.7.1.

aws-sdk-s3 stays at 1.137 (already ships BucketNamespace and the extra checksum accessors). Bump s7cmd 1.4.0 -> 1.5.0 and update CHANGELOG. (1.7.1 over 1.7.0 is docs-only; the vendored runners are identical.)

Tests (test code only; e2e is compile-checked under --cfg e2e_test, never run):
- unit: detect_checksum surfaces every unsupported algorithm and prefers supported ones; check_integrity rejects unsupported checksums; write_verified_output fails cleanly when the temp file cannot be created.
- process/mock: create-bucket help + both-or-neither flag validation + invalid-value rejection; account-regional dry-run namespace log; create-bucket invalid target (key in path); get-object-annotation write-to-unwritable-outfile.
- e2e: account-regional create/head/delete round-trip (env-gated on S7CMD_E2E_ACCOUNT_ID); get-object-annotation write failure.

Verified against 1.7.1: cargo fmt, cargo clippy --all-features --all-targets (default and --cfg e2e_test), and the non-e2e test suite (1085 passed) all clean.

## Contributing

- Bug reports are welcome, but responses are not guaranteed.
- Since this project is considered functionally complete, I will not accept any feature requests.
- If you find this project useful, feel free to fork and modify it as you wish.

🔒 I consider this project “complete” and will maintain it only minimally going forward.
However, I intend to keep the AWS SDK for Rust and other dependencies up to date monthly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for `create-bucket` account-regional bucket namespaces, including `--bucket-namespace account-regional` and paired `--create-bucket-configuration LocationConstraint=<region>`.
  * Updated dry-run output to report the account-regional namespace and `LocationConstraint` settings.
* **Bug Fixes**
  * `get-object-annotation` now rejects unsupported checksum algorithms with a clear integrity error (no crash).
  * Output-file temp preparation failures now exit cleanly without creating partial output.
* **Documentation**
  * Added changelog entry for version 1.5.0.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->