### PR TITLE
fix: port applicable fixes from upstream PRs into s7cmd-owned code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,9 @@ Ports the applicable fixes from s3sync [PR#246](https://github.com/nidor1998/s3s
 [PR#94](https://github.com/nidor1998/s3rm-rs/pull/94), s3ls-rs
 [PR#29](https://github.com/nidor1998/s3ls-rs/pull/29), and s3util-rs
 [PR#25](https://github.com/nidor1998/s3util-rs/pull/25) into s7cmd's own code
-(the CLI builder and the vendored bin runners).
+(the CLI builder and the vendored bin runners). It also includes two independent hardening fixes to s7cmd's own
+`batch-run` / CLI code found in a security review — inline-credential redaction in per-line logs, and a `--parallel`
+upper bound (see **Security** and **Fixed › batch-run** below).
 
 ### Security
 
@@ -22,6 +24,13 @@ Ports the applicable fixes from s3sync [PR#246](https://github.com/nidor1998/s3s
   environment-variable names are still shown. Upstream fixes this in the (unreleased) mains of all four libraries;
   until those ship in released crates, s7cmd enforces the same `hide_env_values` marking when it builds its clap
   command tree, which becomes an idempotent no-op once the upstream releases catch up.
+- `batch-run` no longer echoes inline credential values from a script line into its logs. A per-line command may
+  legally carry a credential on the command line (`--target-secret-access-key`, `--source-secret-access-key`,
+  `--*-access-key`, `--*-session-token`, `--*-sse-c-key`, `--*-sse-c-key-md5`); batch-run logs each line's raw text as
+  the `raw` field on per-line events, and the `warning` / `failure` / `invalid` / `panicked` events are emitted at the
+  default verbosity (and, with `--json-tracing`, into machine-readable JSON). The value of every such credential flag —
+  the same set hidden from `--help` above — is now masked to `****` before the line is logged; a line carrying no
+  credential is logged unchanged.
 
 ### Fixed
 
@@ -48,6 +57,14 @@ Ports the applicable fixes from s3sync [PR#246](https://github.com/nidor1998/s3s
   bucket configured with `varies_by_storage_class` back to S3's default of `all_storage_classes_128K` on a
   get-edit-put roundtrip. (Upstream additionally gains a `--transition-default-minimum-object-size` option; that flag
   arrives in s7cmd with the next s3util-rs release.)
+
+#### batch-run
+
+- `batch-run --parallel` now rejects a value greater than 1024 at parse time (a clean exit 2) instead of accepting an
+  arbitrarily large worker count. A value above `usize::MAX >> 3` reached `tokio::sync::Semaphore::new` and panicked,
+  aborting the whole run with exit 101 before any line executed; the bound also stops an oversized-but-valid value from
+  spawning a runaway number of concurrent commands (file-descriptor / connection exhaustion). `--parallel 0` (use all
+  logical CPUs) is still accepted.
 
 ### Documentation
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,68 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+Ports the applicable fixes from s3sync [PR#246](https://github.com/nidor1998/s3sync/pull/246) /
+[PR#245](https://github.com/nidor1998/s3sync/pull/245), s3rm-rs
+[PR#94](https://github.com/nidor1998/s3rm-rs/pull/94), s3ls-rs
+[PR#29](https://github.com/nidor1998/s3ls-rs/pull/29), and s3util-rs
+[PR#25](https://github.com/nidor1998/s3util-rs/pull/25) into s7cmd's own code
+(the CLI builder and the vendored bin runners).
+
+### Security
+
+- Credential-related command line options no longer display their values in `--help` output when set via environment
+  variables, on every subcommand: access keys, secret access keys, session tokens (`*_ACCESS_KEY`,
+  `*_SECRET_ACCESS_KEY`, `*_SESSION_TOKEN`), and SSE-C key material (`*_SSE_C_KEY`, `*_SSE_C_KEY_MD5`). The
+  environment-variable names are still shown. Upstream fixes this in the (unreleased) mains of all four libraries;
+  until those ship in released crates, s7cmd enforces the same `hide_env_values` marking when it builds its clap
+  command tree, which becomes an idempotent no-op once the upstream releases catch up.
+
+### Fixed
+
+#### cp / mv (ported from s3util-rs PR#25 into the vendored runner)
+
+- A transfer-worker failure that cancels the internal pipeline (e.g. a failed chunk download or a stdout write error
+  during parallel S3-to-stdout downloads) is now reported as a failure (exit code 1) with its error logged, instead of
+  being misreported as a user cancellation (exit code 130) with the error message suppressed. A genuine SIGINT still
+  exits 130.
+- A local target directory spelled with a trailing forward slash (e.g. `out/`) now resolves to `out/<basename>` on
+  Windows as well. Previously the `/` form was only recognized on Unix, so on Windows the storage layer treated the
+  literal key `out/` as a directory and silently wrote nothing (and `mv` would then delete the source).
+- `mv` now rejects moving an S3 object onto itself (`mv s3://b/k s3://b/k`, including directory-style and bucket-only
+  spellings that resolve to the source key). `mv` is copy-then-delete, so a self-move deleted the object it had just
+  written on an unversioned bucket — and still exited 0. Moves between different endpoints with equal bucket/key names
+  are still allowed, and an explicit `--source-version-id` (other than `null`) is still accepted as a
+  version-promotion operation.
+
+#### put-bucket-lifecycle-configuration (adapted from s3util-rs PR#25)
+
+- A top-level `TransitionDefaultMinimumObjectSize` key in the input JSON — as produced by
+  `get-bucket-lifecycle-configuration` — is now rejected with guidance instead of being silently dropped. S3 accepts
+  the value only as a request parameter, never inside the configuration document, so silently dropping it reset a
+  bucket configured with `varies_by_storage_class` back to S3's default of `all_storage_classes_128K` on a
+  get-edit-put roundtrip. (Upstream additionally gains a `--transition-default-minimum-object-size` option; that flag
+  arrives in s7cmd with the next s3util-rs release.)
+
+### Documentation
+
+- Added a "Security assumptions" section to the README, mirroring the sections the upstream PRs added to the
+  s3sync / s3util-rs / s3rm-rs / s3ls-rs READMEs.
+
+### Pending upstream releases
+
+The remaining fixes in the referenced PRs live in the upstream *library* code that s7cmd consumes from crates.io
+(`s3sync = 1.59.0`, `s3util-rs = 1.7.1`, `s3rm-rs = 1.3.8`, `s3ls-rs = 1.0.3`), so they reach s7cmd automatically
+when the upstream crates publish releases containing them and the pins are bumped. Notably: `ONEZONE_IA` naming in
+`--storage-class` help/errors, stable same-second object-version replay ordering, SSE-C ETag source parameters,
+delete-marker size/ETag panics, `Expires`/`expiry-date` parse hardening, stricter S3-path and `--metadata`
+validation, annotation-API force-retry (s3sync PR#245); suspended-versioning buckets treated as versioned and
+delete-marker exclusion from attribute filters in `clean` (s3rm-rs PR#94); `--max-parallel-listings` leaf-scan
+enforcement and exact `--rate-limit-api` rates in `ls` (s3ls-rs PR#29); `--target-request-payer` wiring,
+`--transition-default-minimum-object-size`, transfer-verification hardening, and stricter input-JSON validation
+(`deny_unknown_fields`) in the `cp`/`mv`/bucket-admin family (s3util-rs PR#25).
+
 ## [1.5.0] - 2026-07-11
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "s7cmd"
-version = "1.5.0"
+version = "1.6.0"
 edition = "2024"
 rust-version = "1.91.1"
 license = "Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -440,6 +440,41 @@ library. For details on flags, semantics, and exit codes, refer to:
 Each of these projects (except `batch-run`) also ships its own
 standalone binary, which can be used independently of s7cmd.
 
+## Security assumptions
+
+s7cmd is built on a fundamental security assumption: **both the object storage system and the specific bucket you
+operate on must be trusted.**
+
+Within this trust model, s7cmd implements the security measures you would reasonably expect of an S3 command-line
+tool: encrypted transport (TLS/HTTPS) for data in transit, end-to-end integrity verification for transfers (ETag,
+MD5, SHA256, and CRC checksums), support for server-side encryption, secure handling of credentials through the
+standard AWS credential providers (with credential environment-variable values hidden from `--help` output), and —
+for `ls` — control-character escaping of the object keys, prefixes, and owner names returned by S3.
+These measures protect the confidentiality and integrity of your data against transport-level and accidental
+threats.
+
+However, s7cmd assumes that the storage endpoint is honest and non-adversarial — that it correctly implements the
+S3 API and returns the data, listings, metadata, and checksum values it actually stores, without tampering. Because
+subcommands decide what to transfer, list, or delete from the listings and metadata the endpoint reports, the
+integrity-verification and filtering features are **not** a defense against a malicious or compromised storage
+backend that deliberately returns falsified data, fabricated listings, or forged checksums. Against such an
+adversarial endpoint, these guarantees do not hold.
+
+Crucially, trust must extend to the **bucket**, not just the storage provider. Even when the object storage system
+itself is fully trustworthy, a bucket can still be adversarial — for example, a bucket you do not control, a shared
+bucket writable by others, or one whose objects, metadata, or checksums were crafted by an attacker. If you
+synchronize from, copy from, list, or delete from such a bucket, the data and metadata it serves are already
+untrusted at the source, and s7cmd's guarantees no longer apply. A trusted storage provider hosting an untrusted
+bucket is, for the purposes of this security model, an untrusted source.
+
+Operating on an untrusted, compromised, or non-conformant endpoint or bucket is outside s7cmd's security model.
+Selecting a trustworthy storage provider, and ensuring that every bucket you operate on is one you control or
+trust — including its credentials, encryption, and access policies — remains your responsibility.
+
+This mirrors the "Security assumptions" sections of the underlying
+[s3sync](https://github.com/nidor1998/s3sync) / [s3util-rs](https://github.com/nidor1998/s3util-rs) /
+[s3rm-rs](https://github.com/nidor1998/s3rm-rs) / [s3ls-rs](https://github.com/nidor1998/s3ls-rs) projects.
+
 ## Requirements
 
 - x86_64 Linux (kernel 3.2 or later)

--- a/src/batch_run/executor.rs
+++ b/src/batch_run/executor.rs
@@ -1,6 +1,7 @@
 //! Sequential and parallel execution loops.
 
 use crate::batch_run::progress::Progress;
+use crate::batch_run::redact::redact_secrets;
 use crate::batch_run::summary::Summary;
 use crate::cli::Cmd;
 
@@ -98,7 +99,7 @@ fn log_start(line_no: usize, raw: &str) {
         line = line_no,
         event = "start",
         command = command_token(raw),
-        raw = raw,
+        raw = redact_secrets(raw).as_ref(),
         "line started",
     );
 }
@@ -139,7 +140,7 @@ async fn execute_line(line: PreparedLine, dispatch: &DispatchFn) -> (usize, i32)
                         event = "panicked",
                         exit_code = EXIT_CODE_PANIC,
                         command = command_token(raw_trimmed),
-                        raw = raw_trimmed,
+                        raw = redact_secrets(raw_trimmed).as_ref(),
                         panic = msg.as_str(),
                         "subcommand panicked",
                     );
@@ -156,7 +157,7 @@ async fn execute_line(line: PreparedLine, dispatch: &DispatchFn) -> (usize, i32)
                 reason = reason,
                 exit_code = EXIT_CODE_INVALID_LINE,
                 command = command_token(raw),
-                raw = raw,
+                raw = redact_secrets(raw).as_ref(),
                 "line invalid",
             );
             EXIT_CODE_INVALID_LINE
@@ -203,8 +204,10 @@ fn panic_message(payload: &(dyn std::any::Any + Send)) -> String {
 /// The 3/4/130 literals avoid a cross-module dep just for three numbers;
 /// each bucket matches the progress-bar / summary bucket the code feeds.
 fn log_end(line_no: usize, raw: &str, code: i32) {
-    let raw = raw.trim_end();
-    let command = command_token(raw);
+    let trimmed = raw.trim_end();
+    let command = command_token(trimmed);
+    let redacted = redact_secrets(trimmed);
+    let raw = redacted.as_ref();
     match code {
         0 => tracing::info!(
             line = line_no,

--- a/src/batch_run/executor.rs
+++ b/src/batch_run/executor.rs
@@ -1384,6 +1384,7 @@ mod tests {
     /// further lines run, even though there are more).
     #[tokio::test]
     async fn sequential_dispatch_panic_recovers_and_records_failure() {
+        let _serial = PANIC_CALLSITE_LOCK.lock().await;
         let lines = make_lines(3);
         let (code, summary) = run_sequential(
             lines,
@@ -1404,6 +1405,7 @@ mod tests {
     /// machinery as other failures.
     #[tokio::test]
     async fn sequential_dispatch_panic_continues_with_continue_on_error() {
+        let _serial = PANIC_CALLSITE_LOCK.lock().await;
         // First call panics, subsequent calls return 0 — but
         // `panicking_dispatch` panics on every call, so use a custom
         // dispatch that panics once then returns 0.
@@ -1435,6 +1437,7 @@ mod tests {
     /// Streaming sequential: panic recovery via the channel path.
     #[tokio::test]
     async fn sequential_streaming_dispatch_panic_recovers_and_records_failure() {
+        let _serial = PANIC_CALLSITE_LOCK.lock().await;
         let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
         for line in make_lines(1) {
             tx.send(line).unwrap();
@@ -1453,6 +1456,7 @@ mod tests {
     /// one failed entry, no successes.
     #[tokio::test]
     async fn parallel_dispatch_panic_recovers_and_records_failure() {
+        let _serial = PANIC_CALLSITE_LOCK.lock().await;
         let lines = make_lines(1);
         let (code, summary) = run_parallel(
             lines,
@@ -1469,6 +1473,7 @@ mod tests {
     /// `run_parallel_streaming`: same shape, via the channel.
     #[tokio::test]
     async fn parallel_streaming_dispatch_panic_recovers_and_records_failure() {
+        let _serial = PANIC_CALLSITE_LOCK.lock().await;
         let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
         for line in make_lines(1) {
             tx.send(line).unwrap();
@@ -1489,6 +1494,7 @@ mod tests {
     /// fail_count).
     #[tokio::test]
     async fn sequential_panic_counts_toward_max_errors() {
+        let _serial = PANIC_CALLSITE_LOCK.lock().await;
         let lines = make_lines(5);
         let (code, summary) = run_sequential(
             lines,
@@ -1564,5 +1570,75 @@ mod tests {
         assert_eq!(summary.ok, 0);
         assert_eq!(summary.failed, 0);
         assert_eq!(summary.skipped, 3);
+    }
+
+    /// Serializes every test that drives `execute_line`'s panic-recovery
+    /// `error!`. Concurrent first-hits of that callsite from threads with
+    /// no subscriber can win a lost-update race on tracing's per-callsite
+    /// interest cache and pin it at `Interest::never`, which silently
+    /// drops the event for the capture test below. tokio's Mutex so the
+    /// guard may be held across the tests' await points.
+    static PANIC_CALLSITE_LOCK: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
+
+    /// The panic-recovery `error!` in `execute_line` carries `command` and
+    /// `panic` fields whose expressions only run when a subscriber has the
+    /// event enabled — install one and pin both the exit code and the
+    /// structured payload.
+    #[tokio::test]
+    async fn execute_line_panic_emits_error_event_with_fields() {
+        use std::sync::Mutex;
+        use tracing_subscriber::fmt::MakeWriter;
+
+        let _serial = PANIC_CALLSITE_LOCK.lock().await;
+
+        #[derive(Clone)]
+        struct Buf(Arc<Mutex<Vec<u8>>>);
+        impl std::io::Write for Buf {
+            fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+                self.0.lock().unwrap().extend_from_slice(buf);
+                Ok(buf.len())
+            }
+            fn flush(&mut self) -> std::io::Result<()> {
+                Ok(())
+            }
+        }
+        impl<'a> MakeWriter<'a> for Buf {
+            type Writer = Buf;
+            fn make_writer(&'a self) -> Buf {
+                self.clone()
+            }
+        }
+
+        let sink = Buf(Arc::new(Mutex::new(Vec::new())));
+        let subscriber = tracing_subscriber::fmt()
+            .with_writer(sink.clone())
+            .with_max_level(tracing::Level::ERROR)
+            .with_ansi(false)
+            .finish();
+        let _guard = tracing::subscriber::set_default(subscriber);
+        // Repair any `Interest::never` a concurrent pre-lock first-hit may
+        // have cached for the panic-recovery callsite before our
+        // subscriber registered.
+        tracing::callsite::rebuild_interest_cache();
+
+        let line = make_lines(1).remove(0);
+        let dispatch = panicking_dispatch();
+        let (line_no, code) = execute_line(line, &dispatch).await;
+
+        assert_eq!(line_no, 1);
+        assert_eq!(code, EXIT_CODE_PANIC);
+        let output = String::from_utf8(sink.0.lock().unwrap().clone()).unwrap();
+        assert!(
+            output.contains("subcommand panicked"),
+            "expected the panic event; got: {output}"
+        );
+        assert!(
+            output.contains("create-bucket"),
+            "expected the command field; got: {output}"
+        );
+        assert!(
+            output.contains("synthetic panic for test"),
+            "expected the panic message field; got: {output}"
+        );
     }
 }

--- a/src/batch_run/mod.rs
+++ b/src/batch_run/mod.rs
@@ -10,6 +10,8 @@ pub mod args;
 pub mod executor;
 pub mod parser;
 pub mod progress;
+/// Mask credential values in a batch-run line before it is echoed into logs.
+mod redact;
 pub mod summary;
 pub mod validate;
 
@@ -142,7 +144,7 @@ fn check_format_lines<R: BufRead>(mut reader: R, source: &str) -> bool {
                     event = "invalid",
                     invalid_kind = "tokenize",
                     reason = e.to_string(),
-                    raw = line.trim_end(),
+                    raw = redact::redact_secrets(line.trim_end()).as_ref(),
                     "line invalid",
                 );
                 return true;
@@ -158,7 +160,7 @@ fn check_format_lines<R: BufRead>(mut reader: R, source: &str) -> bool {
                     event = "invalid",
                     invalid_kind = "parse",
                     reason = clap_error_summary(&s),
-                    raw = line.trim_end(),
+                    raw = redact::redact_secrets(line.trim_end()).as_ref(),
                     "line invalid",
                 );
                 return true;
@@ -173,7 +175,7 @@ fn check_format_lines<R: BufRead>(mut reader: R, source: &str) -> bool {
                     event = "invalid",
                     invalid_kind = "empty",
                     reason = "empty command",
-                    raw = line.trim_end(),
+                    raw = redact::redact_secrets(line.trim_end()).as_ref(),
                     "line invalid",
                 );
                 return true;
@@ -188,7 +190,7 @@ fn check_format_lines<R: BufRead>(mut reader: R, source: &str) -> bool {
                 event = "invalid",
                 invalid_kind = "validate",
                 reason = flatten(&e.to_string()),
-                raw = line.trim_end(),
+                raw = redact::redact_secrets(line.trim_end()).as_ref(),
                 "line invalid",
             );
             return true;

--- a/src/batch_run/redact.rs
+++ b/src/batch_run/redact.rs
@@ -1,0 +1,379 @@
+//! Redact secret argument values from a batch-run line before it is echoed
+//! into logs.
+//!
+//! `batch-run` logs each line's raw text as the `raw` structured field on
+//! per-line events (`start` / `success` / `warning` / `skipped` / `failure`
+//! / `invalid` / `panicked`) so the user can tell which subcommand each
+//! event belongs to. `log_end`'s failure/warning arms and every `invalid`
+//! entry emit at `warn`/`error` level — visible at the default verbosity
+//! with no `-v` — and `--json-tracing` writes `raw` into machine-readable
+//! JSON. A line may legally carry a credential inline (e.g.
+//! `cp /f s3://b/k --target-secret-access-key wJalr...` or
+//! `--source-sse-c-key <base64-key>`), so without masking the secret would
+//! be copied verbatim to stderr / JSON on any non-success outcome.
+//!
+//! [`redact_secrets`] masks the value of every known secret flag — the same
+//! set `hide_credential_env_values` (cli.rs) hides from `--help`: access
+//! keys, secret access keys, session tokens, and SSE-C key material.
+
+use std::borrow::Cow;
+
+/// Placeholder written in place of a redacted secret value.
+const REDACTED: &str = "****";
+
+/// Flag-name substrings that mark a `--flag` whose value is a credential /
+/// secret. Mirrors the id predicate in `hide_credential_env_values`
+/// (cli.rs): `access-key` covers `--*-access-key` and
+/// `--*-secret-access-key`; `session-token` covers `--*-session-token`;
+/// `sse-c-key` covers `--*-sse-c-key` and the `--*-sse-c-key-md5` digests.
+const SECRET_FLAG_SUBSTRINGS: [&str; 3] = ["access-key", "session-token", "sse-c-key"];
+
+/// True when `flag` (a token beginning with `-`, minus any trailing
+/// `=value`) names a credential/secret argument whose value must not be
+/// logged.
+fn is_secret_flag(flag: &str) -> bool {
+    let name = flag.trim_start_matches('-');
+    SECRET_FLAG_SUBSTRINGS.iter().any(|s| name.contains(s))
+}
+
+/// Redact secret values from a raw batch-run line before logging.
+///
+/// Returns [`Cow::Borrowed`] unchanged when the line carries no secret flag
+/// (the overwhelmingly common case — a single cheap substring scan, no
+/// allocation, no tokenization). When a secret *is* present the line is
+/// tokenized and every secret flag's value is replaced with `****`, then
+/// space-joined; exact original spacing/quoting is not preserved for those
+/// lines, but the command stays identifiable and no secret survives. A line
+/// that cannot be tokenized (unbalanced quotes) but still contains a secret
+/// flag falls back to a whitespace-level scrub so the secret is masked even
+/// on a malformed line.
+pub(crate) fn redact_secrets(raw: &str) -> Cow<'_, str> {
+    // Fast path: no secret-flag substring anywhere → nothing to redact.
+    // Skips tokenization for the ~all lines that carry no credential.
+    if !SECRET_FLAG_SUBSTRINGS.iter().any(|s| raw.contains(s)) {
+        return Cow::Borrowed(raw);
+    }
+    match shlex::split(raw) {
+        // Substring matched but no token was actually a secret *flag* value
+        // (e.g. a key literally named `access-key.txt`): nothing masked, so
+        // return the original line untouched.
+        Some(tokens) => match redact_tokens(&tokens) {
+            Some(redacted) => Cow::Owned(redacted),
+            None => Cow::Borrowed(raw),
+        },
+        // Unbalanced quoting: shlex can't tokenize. Best-effort scrub so a
+        // secret on an otherwise-malformed line still does not leak.
+        None => match redact_whitespace(raw) {
+            Some(redacted) => Cow::Owned(redacted),
+            None => Cow::Borrowed(raw),
+        },
+    }
+}
+
+/// Mask secret-flag values in a shlex token vector. Returns `Some(rejoined)`
+/// when at least one value was masked, `None` when no token was a secret
+/// flag (so the caller can keep the original line verbatim).
+fn redact_tokens(tokens: &[String]) -> Option<String> {
+    let mut out: Vec<Cow<str>> = Vec::with_capacity(tokens.len());
+    let mut masked = false;
+    let mut i = 0;
+    while i < tokens.len() {
+        let tok = tokens[i].as_str();
+        // `--flag=value` form: mask everything after the first `=`.
+        if tok.starts_with('-')
+            && let Some(eq) = tok.find('=')
+            && is_secret_flag(&tok[..eq])
+        {
+            out.push(Cow::Owned(format!("{}={REDACTED}", &tok[..eq])));
+            masked = true;
+            i += 1;
+            continue;
+        }
+        // `--flag value` form: keep the flag, mask the following token.
+        if tok.starts_with('-') && is_secret_flag(tok) {
+            out.push(Cow::Borrowed(tok));
+            if i + 1 < tokens.len() {
+                out.push(Cow::Borrowed(REDACTED));
+                masked = true;
+                i += 2;
+                continue;
+            }
+            // Secret flag with no following value (malformed line) — nothing
+            // to mask for it.
+            i += 1;
+            continue;
+        }
+        out.push(Cow::Borrowed(tok));
+        i += 1;
+    }
+    masked.then(|| join_tokens(&out))
+}
+
+/// Whitespace-level fallback used when a line cannot be shlex-tokenized
+/// (unbalanced quotes) but still contains a secret-flag substring. Splits on
+/// ASCII whitespace and masks the value after any secret flag, both
+/// `--flag value` and `--flag=value`. Returns `Some` only when a value was
+/// masked. Quoting is not interpreted — acceptable because this path is only
+/// reached for an already-malformed line whose exact formatting is moot; the
+/// sole goal is that the secret does not survive.
+fn redact_whitespace(raw: &str) -> Option<String> {
+    let mut out: Vec<String> = Vec::new();
+    let mut masked = false;
+    let mut expect_value = false;
+    for word in raw.split_whitespace() {
+        if expect_value {
+            out.push(REDACTED.to_string());
+            masked = true;
+            expect_value = false;
+            continue;
+        }
+        if word.starts_with('-')
+            && let Some(eq) = word.find('=')
+            && is_secret_flag(&word[..eq])
+        {
+            out.push(format!("{}={REDACTED}", &word[..eq]));
+            masked = true;
+            continue;
+        }
+        if word.starts_with('-') && is_secret_flag(word) {
+            out.push(word.to_string());
+            expect_value = true;
+            continue;
+        }
+        out.push(word.to_string());
+    }
+    masked.then(|| out.join(" "))
+}
+
+/// Re-join redacted tokens into a single space-separated line. The result is
+/// used only as the human-readable `raw` field on a log event — it is never
+/// re-parsed or executed — so exact shell quoting is unnecessary (and shell
+/// quoting would wrap the `****` placeholder in quotes). A value that
+/// originally contained spaces simply appears as separate words; per the
+/// [`redact_secrets`] contract, exact spacing/quoting is not preserved for a
+/// redacted line.
+fn join_tokens(tokens: &[Cow<str>]) -> String {
+    tokens
+        .iter()
+        .map(|c| c.as_ref())
+        .collect::<Vec<&str>>()
+        .join(" ")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ---- is_secret_flag ----
+
+    #[test]
+    fn is_secret_flag_matches_every_credential_variant() {
+        for flag in [
+            "--target-access-key",
+            "--source-access-key",
+            "--target-secret-access-key",
+            "--source-secret-access-key",
+            "--target-session-token",
+            "--source-session-token",
+            "--source-sse-c-key",
+            "--target-sse-c-key",
+            "--source-sse-c-key-md5",
+            "--target-sse-c-key-md5",
+        ] {
+            assert!(is_secret_flag(flag), "{flag} should be treated as secret");
+        }
+    }
+
+    #[test]
+    fn is_secret_flag_rejects_non_credential_flags() {
+        for flag in [
+            "--target-region",
+            "--target-endpoint-url",
+            "--dry-run",
+            "--tagging",
+            "--target-profile",
+            "--json-tracing",
+            "--",
+            "-v",
+        ] {
+            assert!(!is_secret_flag(flag), "{flag} must not be masked");
+        }
+    }
+
+    // ---- redact_secrets: nothing to redact ----
+
+    #[test]
+    fn no_secret_flag_returns_borrowed_unchanged() {
+        let raw = "cp s3://b/key /tmp/dst --target-region us-east-1";
+        let out = redact_secrets(raw);
+        assert!(
+            matches!(out, Cow::Borrowed(_)),
+            "expected zero-alloc borrow"
+        );
+        assert_eq!(out, raw);
+    }
+
+    #[test]
+    fn empty_line_is_borrowed_unchanged() {
+        let out = redact_secrets("");
+        assert!(matches!(out, Cow::Borrowed(_)));
+        assert_eq!(out, "");
+    }
+
+    #[test]
+    fn substring_in_non_flag_token_is_not_masked() {
+        // A positional key that merely contains "access-key" must survive:
+        // it is not a `--flag`, so nothing is redacted and the original line
+        // is returned untouched.
+        let raw = "cp s3://b/my-access-key-notes.txt /tmp/out";
+        let out = redact_secrets(raw);
+        assert_eq!(out, raw);
+    }
+
+    // ---- redact_secrets: `--flag value` form ----
+
+    #[test]
+    fn masks_secret_access_key_space_form() {
+        let out = redact_secrets(
+            "head-bucket s3://b --target-secret-access-key wJalrXUtnFEMISECRET --target-region us-east-1",
+        );
+        assert!(!out.contains("wJalrXUtnFEMISECRET"), "secret leaked: {out}");
+        assert!(
+            out.contains("--target-secret-access-key ****"),
+            "got: {out}"
+        );
+        // Non-secret parts survive.
+        assert!(out.contains("head-bucket"));
+        assert!(out.contains("s3://b"));
+        assert!(out.contains("--target-region us-east-1"));
+    }
+
+    #[test]
+    fn masks_access_key_id_session_token_and_sse_c_key() {
+        for (flag, value) in [
+            ("--target-access-key", "AKIAIOSFODNN7EXAMPLE"),
+            ("--source-session-token", "FQoGZXIvYXdzSESSIONTOKEN"),
+            ("--source-sse-c-key", "MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI="),
+            ("--target-sse-c-key-md5", "abcdEXAMPLEmd5=="),
+        ] {
+            let raw = format!("cp s3://b/k /tmp/o {flag} {value}");
+            let out = redact_secrets(&raw);
+            assert!(!out.contains(value), "{flag}: secret leaked: {out}");
+            assert!(out.contains(&format!("{flag} ****")), "{flag}: got: {out}");
+        }
+    }
+
+    #[test]
+    fn masks_multiple_secrets_in_one_line() {
+        let out = redact_secrets(
+            "cp /f s3://b/k --target-access-key AKIAEXAMPLEID --target-secret-access-key SECRETVAL --target-session-token TOKVAL",
+        );
+        assert!(!out.contains("AKIAEXAMPLEID"), "got: {out}");
+        assert!(!out.contains("SECRETVAL"), "got: {out}");
+        assert!(!out.contains("TOKVAL"), "got: {out}");
+        assert_eq!(out.matches("****").count(), 3, "all three masked: {out}");
+    }
+
+    #[test]
+    fn secret_flag_as_last_token_without_value_does_not_panic_or_change() {
+        // Missing value (malformed line): there is no secret to mask, so the
+        // line is returned unchanged rather than reconstructed.
+        let raw = "create-bucket s3://b --target-secret-access-key";
+        let out = redact_secrets(raw);
+        assert_eq!(out, raw);
+    }
+
+    // ---- redact_secrets: `--flag=value` form ----
+
+    #[test]
+    fn masks_secret_equals_form() {
+        let out = redact_secrets("head-bucket s3://b --target-secret-access-key=wJalrSECRETeq");
+        assert!(!out.contains("wJalrSECRETeq"), "got: {out}");
+        assert!(
+            out.contains("--target-secret-access-key=****"),
+            "got: {out}"
+        );
+    }
+
+    #[test]
+    fn masks_empty_equals_value() {
+        // `--flag=` with an empty value still gets the placeholder; harmless
+        // (no secret was present) and keeps the branch uniform.
+        let out = redact_secrets("head-bucket s3://b --target-secret-access-key=");
+        assert!(
+            out.contains("--target-secret-access-key=****"),
+            "got: {out}"
+        );
+    }
+
+    // ---- redact_secrets: quoted values with spaces ----
+
+    #[test]
+    fn masks_quoted_value_with_spaces() {
+        // Real AWS secrets never contain spaces, but a quoted value must not
+        // slip through the token boundary: the whole quoted token is masked.
+        let out = redact_secrets(r#"head-bucket s3://b --source-sse-c-key "a b c secret""#);
+        assert!(!out.contains("a b c secret"), "got: {out}");
+        assert!(out.contains("****"), "got: {out}");
+    }
+
+    // ---- redact_secrets: malformed (unbalanced quote) fallback ----
+
+    #[test]
+    fn masks_secret_even_when_line_cannot_be_tokenized() {
+        // Unbalanced quote → shlex::split returns None → whitespace fallback.
+        let out = redact_secrets(r#"cp --target-secret-access-key SECRETUNBALANCED "unterminated"#);
+        assert!(!out.contains("SECRETUNBALANCED"), "secret leaked: {out}");
+        assert!(out.contains("****"), "got: {out}");
+    }
+
+    #[test]
+    fn malformed_line_without_secret_flag_is_unchanged() {
+        // Substring present (in a non-flag token) AND unbalanced quotes: the
+        // fallback finds no secret flag, so the line is returned as-is.
+        let raw = r#"cp "unterminated s3://b/access-key-thing"#;
+        let out = redact_secrets(raw);
+        assert_eq!(out, raw);
+    }
+
+    // ---- identifiability: the subcommand token survives redaction ----
+
+    #[test]
+    fn redacted_line_keeps_leading_subcommand_token() {
+        let out = redact_secrets("cp s3://b/k /tmp/o --target-secret-access-key SECRET");
+        assert!(
+            out.starts_with("cp "),
+            "command must stay identifiable: {out}"
+        );
+    }
+
+    #[test]
+    fn non_secret_equals_flag_passes_through_while_secret_is_masked() {
+        // A non-secret `--flag=value` (has `=` but is not a credential) must
+        // survive untouched on a line that also carries a masked secret —
+        // covers the `is_secret_flag(&tok[..eq]) == false` fall-through in the
+        // `--flag=value` branch.
+        let out = redact_secrets(
+            "cp s3://b/k --target-region=us-east-1 --target-secret-access-key SECRETXYZ",
+        );
+        assert!(out.contains("--target-region=us-east-1"), "got: {out}");
+        assert!(!out.contains("SECRETXYZ"), "secret leaked: {out}");
+        assert!(
+            out.contains("--target-secret-access-key ****"),
+            "got: {out}"
+        );
+    }
+
+    #[test]
+    fn masks_equals_form_secret_when_line_cannot_be_tokenized() {
+        // Malformed (unbalanced quote) line carrying the `--flag=value` secret
+        // form: the whitespace fallback must still mask it (covers the
+        // equals-form branch of `redact_whitespace`).
+        let out = redact_secrets(r#"cp --target-secret-access-key=SECRETEQMALF "unterminated"#);
+        assert!(!out.contains("SECRETEQMALF"), "secret leaked: {out}");
+        assert!(
+            out.contains("--target-secret-access-key=****"),
+            "got: {out}"
+        );
+    }
+}

--- a/src/clean_bin/indicator.rs
+++ b/src/clean_bin/indicator.rs
@@ -1,6 +1,9 @@
 // Vendored from s3rm-rs@1.3.4
 //   src/bin/s3rm/indicator.rs
-// Adjustments: stripped #[cfg(test)] mod tests
+// Adjustments: stripped #[cfg(test)] mod tests;
+//              final-summary trailing newline made EPIPE-safe (a bare
+//              eprintln! panics when stderr is a closed pipe, turning a
+//              successful run into exit 101; same fix as the sync_bin copy)
 
 // Progress indicator adapted from s3sync's `bin/s3sync/cli/indicator.rs`.
 //
@@ -137,7 +140,11 @@ pub fn show_indicator(
                             HumanDuration(elapsed),
                         ));
 
-                        eprintln!();
+                        // Ignore BrokenPipe/other write errors so a closed
+                        // stderr (e.g. `s7cmd clean ... 2>&1 | head`) does
+                        // not panic the indicator task — the panic would be
+                        // mapped to exit 101 for an otherwise successful run.
+                        let _ = writeln!(io::stderr());
                         let _ = io::stderr().flush();
                     }
 

--- a/src/clean_bin/mod.rs
+++ b/src/clean_bin/mod.rs
@@ -11,6 +11,10 @@
 //              exit code 2 on Err instead. run() now returns Result<i32>
 //              instead of calling std::process::exit (so it can be invoked
 //              from batch-run without killing the process mid-batch).
+//              "Deletion cancelled." made EPIPE-safe (a bare eprintln!
+//              panics when stderr is a closed pipe).
+
+use std::io::Write;
 
 use anyhow::Result;
 use tracing::{debug, error};
@@ -58,7 +62,9 @@ pub async fn run(config: Config) -> Result<i32> {
         if let Err(e) = pipeline.check_prerequisites().await {
             pipeline.close_stats_sender();
             if is_cancelled_error(&e) {
-                eprintln!("Deletion cancelled.");
+                // Ignore write errors (EPIPE): a closed stderr must not
+                // panic what is otherwise a clean, successful cancellation.
+                let _ = writeln!(std::io::stderr(), "Deletion cancelled.");
                 debug!("deletion cancelled by user.");
                 return Ok(EXIT_CODE_SUCCESS);
             }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -145,6 +145,30 @@ pub struct Cli {
     pub command: Option<Cmd>,
 }
 
+/// Upper bound on `batch-run --parallel`. An unbounded worker count has two
+/// failure modes: `tokio::sync::Semaphore::new` panics — aborting the whole
+/// process with exit 101 — once the value exceeds `usize::MAX >> 3`, and even
+/// a large-but-valid value would spawn that many concurrent dispatch tasks,
+/// exhausting file descriptors / connections. 1024 concurrent whole-subcommand
+/// executions is already far beyond any practical batch workload (each line
+/// may itself be a multi-worker transfer), so the cap stays generous while
+/// keeping the knob safe. `0` (use all logical CPUs) is always accepted.
+pub(crate) const MAX_PARALLEL: usize = 1024;
+
+/// Value parser for `--parallel`. Accepts `0..=MAX_PARALLEL`, rejecting an
+/// oversized or non-numeric value at clap parse time (clean exit 2) rather
+/// than letting it reach `Semaphore::new` and panic (exit 101). Mirrors the
+/// custom-parser style used for `presign --expires-in` upstream.
+fn parse_parallel(s: &str) -> Result<usize, String> {
+    let n: usize = s
+        .parse()
+        .map_err(|_| format!("invalid value '{s}': expected an integer in 0..={MAX_PARALLEL}"))?;
+    if n > MAX_PARALLEL {
+        return Err(format!("--parallel must be no more than {MAX_PARALLEL}"));
+    }
+    Ok(n)
+}
+
 #[derive(clap::Args, Clone, Debug)]
 pub struct BatchRunArgs {
     /// Path to a script file with s7cmd commands, or `-` to read from stdin.
@@ -152,8 +176,10 @@ pub struct BatchRunArgs {
     pub script: String,
 
     /// Number of commands to run concurrently. 1 = sequential (default).
-    /// 0 = use all logical CPUs.
-    #[arg(long, default_value_t = 1, value_name = "N")]
+    /// 0 = use all logical CPUs. Must be no more than `MAX_PARALLEL` (1024);
+    /// an oversized value is rejected at parse time rather than panicking the
+    /// tokio semaphore.
+    #[arg(long, default_value_t = 1, value_name = "N", value_parser = parse_parallel)]
     pub parallel: usize,
 
     /// Execute commands as they are read from stdin (no progress bar).
@@ -665,5 +691,45 @@ mod tests {
                 "`{sub_name} --{arg_id}` must hide its env value in help output",
             );
         }
+    }
+
+    // ---- --parallel value parser (MAX_PARALLEL cap) ----
+    //
+    // An unbounded `--parallel` reaches `tokio::sync::Semaphore::new`, which
+    // panics (aborting the process, exit 101) once the value exceeds
+    // `usize::MAX >> 3`. `parse_parallel` rejects out-of-range input at clap
+    // parse time (exit 2) instead.
+
+    #[test]
+    fn parse_parallel_accepts_zero_one_and_max() {
+        // 0 = "all logical CPUs", 1 = sequential, MAX_PARALLEL = the ceiling.
+        assert_eq!(parse_parallel("0"), Ok(0));
+        assert_eq!(parse_parallel("1"), Ok(1));
+        assert_eq!(parse_parallel(&MAX_PARALLEL.to_string()), Ok(MAX_PARALLEL));
+    }
+
+    #[test]
+    fn parse_parallel_rejects_just_over_max() {
+        let err = parse_parallel(&(MAX_PARALLEL + 1).to_string()).unwrap_err();
+        assert!(err.contains("no more than"), "got: {err}");
+    }
+
+    #[test]
+    fn parse_parallel_rejects_semaphore_panic_range() {
+        // tokio's Semaphore::new panics above `usize::MAX >> 3`; the value one
+        // past that boundary — and `usize::MAX` itself — must be rejected here
+        // rather than ever reaching `Semaphore::new`.
+        let boundary = (usize::MAX >> 3).wrapping_add(1);
+        assert!(parse_parallel(&boundary.to_string()).is_err());
+        assert!(parse_parallel(&usize::MAX.to_string()).is_err());
+    }
+
+    #[test]
+    fn parse_parallel_rejects_overflow_and_non_numeric() {
+        // Beyond usize::MAX → clean parse error (no overflow/panic).
+        assert!(parse_parallel("99999999999999999999999999").is_err());
+        assert!(parse_parallel("abc").is_err());
+        assert!(parse_parallel("").is_err());
+        assert!(parse_parallel("-1").is_err());
     }
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -176,7 +176,7 @@ pub struct BatchRunArgs {
     pub script: String,
 
     /// Number of commands to run concurrently. 1 = sequential (default).
-    /// 0 = use all logical CPUs. Must be no more than `MAX_PARALLEL` (1024);
+    /// 0 = use all logical CPUs. Must be no more than 1024;
     /// an oversized value is rejected at parse time rather than panicking the
     /// tokio semaphore.
     #[arg(long, default_value_t = 1, value_name = "N", value_parser = parse_parallel)]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -406,8 +406,13 @@ pub enum Cmd {
 ///
 /// `hide(true)` alone only suppresses the flag from `--help`. clap_complete
 /// does not honor `hide(true)` for args, so we additionally clear the long
-/// name to keep it out of generated completion scripts. The arg id stays
-/// so `FromArgMatches` still derives `auto_complete_shell: None` cleanly;
+/// name to keep it out of generated completion scripts, and clear the env
+/// source: upstream declares the arg with `env`, so an exported
+/// `AUTO_COMPLETE_SHELL` would otherwise still populate it and fire its
+/// clap side effects (`default_value_if` defaulting sync source/target to
+/// `s3://ignored`, `required_unless_present` lifting required util targets)
+/// even though dispatch ignores the parsed value. With both cleared, the
+/// arg id stays and `FromArgMatches` derives `auto_complete_shell: None`;
 /// users who want completions use the top-level `--auto-complete-shell`.
 #[allow(dead_code)] // used from main.rs; cli_routing integration test includes this file directly
 pub fn cli_command() -> clap::Command {
@@ -439,7 +444,9 @@ fn build_cli_command() -> clap::Command {
                 .any(|a| a.get_id().as_str() == "auto_complete_shell");
             let sub = if has_flag {
                 sub.mut_arg("auto_complete_shell", |a| {
-                    a.hide(true).long(None::<&'static str>)
+                    a.hide(true)
+                        .long(None::<&'static str>)
+                        .env(None::<&'static str>)
                 })
             } else {
                 sub

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -437,16 +437,50 @@ fn build_cli_command() -> clap::Command {
             let has_flag = sub
                 .get_arguments()
                 .any(|a| a.get_id().as_str() == "auto_complete_shell");
-            if has_flag {
+            let sub = if has_flag {
                 sub.mut_arg("auto_complete_shell", |a| {
                     a.hide(true).long(None::<&'static str>)
                 })
             } else {
                 sub
-            }
+            };
+            hide_credential_env_values(sub)
         });
     }
     cmd
+}
+
+/// Mark every env-backed credential argument `hide_env_values` so a secret
+/// exported through the environment is not echoed into `--help` output
+/// (CI logs, terminal scrollback, pasted bug reports). clap renders the
+/// current value of an arg's env var into help text by default; the env var
+/// *name* stays visible, only the value is suppressed.
+///
+/// Upstream fixes this at the derive level — s3sync PR#246, s3rm-rs PR#94,
+/// s3ls-rs PR#29, and s3util-rs PR#25 all add `hide_env_values = true` to
+/// their credential args — but those changes are not yet in the released
+/// crates s7cmd pins, so the same hardening is applied here to the built
+/// `Command` tree. Once the upstream releases catch up this becomes an
+/// idempotent no-op.
+///
+/// The id predicate matches the exact set upstream hides: access keys,
+/// secret access keys, session tokens (`*access_key*`, `*session_token*`)
+/// and SSE-C key material (`*sse_c_key*`, which also covers the
+/// `*_sse_c_key_md5` digests).
+fn hide_credential_env_values(mut sub: clap::Command) -> clap::Command {
+    let sensitive_ids: Vec<clap::Id> = sub
+        .get_arguments()
+        .filter(|a| {
+            let id = a.get_id().as_str();
+            (id.contains("access_key") || id.contains("session_token") || id.contains("sse_c_key"))
+                && a.get_env().is_some()
+        })
+        .map(|a| a.get_id().clone())
+        .collect();
+    for id in sensitive_ids {
+        sub = sub.mut_arg(id, |a| a.hide_env_values(true));
+    }
+    sub
 }
 
 #[cfg(test)]
@@ -555,5 +589,74 @@ mod tests {
             .find(|a| a.get_id().as_str() == "auto_complete_shell")
             .expect("top-level --auto-complete-shell is missing");
         assert_eq!(arg.get_long(), Some("auto-complete-shell"));
+    }
+
+    /// Every env-backed credential argument across every subcommand must be
+    /// `hide_env_values` so `--help` never echoes a secret exported through
+    /// the environment. Mirrors the upstream guard test added by s3util-rs
+    /// PR#25; here the invariant is enforced by `hide_credential_env_values`
+    /// because the released upstream crates do not yet carry their own
+    /// `hide_env_values = true` fixes (s3sync PR#246, s3rm-rs PR#94,
+    /// s3ls-rs PR#29, s3util-rs PR#25).
+    #[test]
+    fn credential_args_hide_env_values_in_every_subcommand() {
+        fn check(cmd: &clap::Command, path: &str, checked: &mut usize) {
+            for arg in cmd.get_arguments() {
+                let id = arg.get_id().as_str();
+                let sensitive = id.contains("access_key")
+                    || id.contains("session_token")
+                    || id.contains("sse_c_key");
+                if sensitive && arg.get_env().is_some() {
+                    *checked += 1;
+                    assert!(
+                        arg.is_hide_env_values_set() || arg.is_hide_env_set(),
+                        "{path} --{id}: env-backed credential arg must hide its env value in help output"
+                    );
+                }
+            }
+            for sub in cmd.get_subcommands() {
+                check(sub, &format!("{path} {}", sub.get_name()), checked);
+            }
+        }
+
+        let cmd = cli_command();
+        let mut checked = 0;
+        check(&cmd, cmd.get_name(), &mut checked);
+        // sync and cp/mv alone contribute 10 credential args each, and the
+        // ~40 CommonClientArgs-based subcommands 3 each; a low count means
+        // the walk (or the mutation loop) went wrong.
+        assert!(checked >= 100, "only {checked} credential args found");
+    }
+
+    /// The mutation must reach the args embedded from every upstream crate,
+    /// not only s3util-rs. Spot-check one representative credential arg per
+    /// upstream parser: sync (s3sync), clean (s3rm-rs), ls (s3ls-rs), and
+    /// cp (s3util-rs) — including the SSE-C key material on sync/cp.
+    #[test]
+    fn credential_args_hidden_for_each_upstream_parser() {
+        let cmd = cli_command();
+        for (sub_name, arg_id) in [
+            ("sync", "source_access_key"),
+            ("sync", "target_sse_c_key"),
+            ("sync", "target_sse_c_key_md5"),
+            ("clean", "target_secret_access_key"),
+            ("ls", "target_session_token"),
+            ("cp", "source_sse_c_key"),
+            ("mv", "target_access_key"),
+            ("rename", "source_session_token"),
+            ("head-object", "source_sse_c_key_md5"),
+        ] {
+            let sub = cmd
+                .find_subcommand(sub_name)
+                .unwrap_or_else(|| panic!("subcommand `{sub_name}` missing"));
+            let arg = sub
+                .get_arguments()
+                .find(|a| a.get_id().as_str() == arg_id)
+                .unwrap_or_else(|| panic!("`{sub_name}` lost its `{arg_id}` arg"));
+            assert!(
+                arg.is_hide_env_values_set(),
+                "`{sub_name} --{arg_id}` must hide its env value in help output",
+            );
+        }
     }
 }

--- a/src/dispatch.rs
+++ b/src/dispatch.rs
@@ -273,6 +273,12 @@ pub async fn dispatch(cmd: Cmd) -> i32 {
             status_to_exit(util_bin::cli::run_get_bucket_versioning(args, client_config).await)
         }
         Cmd::PutBucketVersioning(args) => {
+            // Validated here, not in the runner: upstream's validate_state_flag
+            // calls process::exit(2), which would kill a whole batch-run.
+            if let Err(e) = util_bin::cli::put_bucket_versioning::check_state_flag(&args) {
+                let _ = e.print();
+                return 2;
+            }
             let client_config = args.common.build_client_config();
             unit_to_exit(util_bin::cli::run_put_bucket_versioning(args, client_config).await)
         }
@@ -390,6 +396,13 @@ pub async fn dispatch(cmd: Cmd) -> i32 {
             )
         }
         Cmd::PutBucketAccelerateConfiguration(args) => {
+            // See Cmd::PutBucketVersioning for why validation happens here.
+            if let Err(e) =
+                util_bin::cli::put_bucket_accelerate_configuration::check_state_flag(&args)
+            {
+                let _ = e.print();
+                return 2;
+            }
             let client_config = args.common.build_client_config();
             unit_to_exit(
                 util_bin::cli::run_put_bucket_accelerate_configuration(args, client_config).await,
@@ -401,6 +414,11 @@ pub async fn dispatch(cmd: Cmd) -> i32 {
             status_to_exit(util_bin::cli::run_get_bucket_request_payment(args, client_config).await)
         }
         Cmd::PutBucketRequestPayment(args) => {
+            // See Cmd::PutBucketVersioning for why validation happens here.
+            if let Err(e) = util_bin::cli::put_bucket_request_payment::check_state_flag(&args) {
+                let _ = e.print();
+                return 2;
+            }
             let client_config = args.common.build_client_config();
             unit_to_exit(util_bin::cli::run_put_bucket_request_payment(args, client_config).await)
         }

--- a/src/util_bin/cli/indicator.rs
+++ b/src/util_bin/cli/indicator.rs
@@ -361,6 +361,46 @@ mod tests {
         join_handle.await.unwrap();
     }
 
+    // Ported from s3util-rs PR#25 (post-1.7.1), adapted to the vendored
+    // 7-parameter show_indicator signature.
+    #[tokio::test]
+    async fn indicator_counts_mismatches_as_warnings() {
+        // ETagMismatch / ChecksumMismatch must bump both their own counter and
+        // the warning counter, and show_result must render the "mismatch"
+        // verification status for both dimensions — here with the
+        // log_sync_summary arm enabled as well.
+        let (stats_sender, stats_receiver) = async_channel::unbounded();
+        let join_handle = show_indicator(
+            stats_receiver,
+            false,
+            true,
+            true,
+            String::new(),
+            "src".to_string(),
+            "dst".to_string(),
+        );
+
+        stats_sender
+            .send(SyncStatistics::SyncBytes(1))
+            .await
+            .unwrap();
+        stats_sender
+            .send(SyncStatistics::ETagMismatch {
+                key: "test".to_string(),
+            })
+            .await
+            .unwrap();
+        stats_sender
+            .send(SyncStatistics::ChecksumMismatch {
+                key: "test".to_string(),
+            })
+            .await
+            .unwrap();
+        stats_sender.close();
+
+        join_handle.await.unwrap();
+    }
+
     #[test]
     fn verification_status_etag_skipped_and_checksum_failed() {
         let (etag, checksum) = verification_status(0, 0, 0, 1);

--- a/src/util_bin/cli/mod.rs
+++ b/src/util_bin/cli/mod.rs
@@ -3,6 +3,12 @@
 // Adjustments: stripped #[cfg(test)] mod tests; commented out per-subcommand
 //              pub mod declarations (re-enabled per task as files land);
 //              kept ExitStatus, EXIT_CODE_*, run_copy_phase, build_rate_limiter.
+// Includes fixes ported from s3util-rs PR#25 (post-1.7.1):
+//   - is_user_cancellation: a worker failure that cancels the pipeline token
+//     is reported as a failure (exit 1), not a SIGINT cancellation (exit 130);
+//   - extract_keys: a local target with a trailing '/' resolves to
+//     <dir>/<basename> on every platform (adapted to 1.7.1's
+//     fs_util::is_key_a_directory — has_trailing_separator lands later).
 
 use std::sync::Arc;
 use std::sync::atomic::AtomicBool;
@@ -16,6 +22,7 @@ use s3util_rs::Config;
 use s3util_rs::storage::Storage;
 use s3util_rs::storage::StorageFactory;
 use s3util_rs::storage::local::LocalStorageFactory;
+use s3util_rs::storage::local::fs_util;
 use s3util_rs::storage::s3::S3StorageFactory;
 use s3util_rs::transfer::{TransferDirection, TransferOutcome, detect_direction};
 use s3util_rs::types::StoragePath;
@@ -555,11 +562,7 @@ pub async fn run_copy_phase(config: Config) -> Result<CopyPhase> {
     // Wait for indicator to finish
     let _ = indicator_handle.await;
 
-    // ctrl_c_handler is the only code path that cancels this token, so an
-    // observed cancellation means SIGINT was received. Snapshot the token
-    // here so callers (run_cp's wrapper, run_mv) see the same bool the
-    // pipeline did.
-    let cancelled = cancellation_token.is_cancelled();
+    let cancelled = is_user_cancellation(cancellation_token.is_cancelled(), &transfer_result);
     let has_warning = has_warning.load(std::sync::atomic::Ordering::SeqCst);
 
     Ok(CopyPhase {
@@ -570,6 +573,29 @@ pub async fn run_copy_phase(config: Config) -> Result<CopyPhase> {
         cancelled,
         has_warning,
     })
+}
+
+/// Decide whether a finished copy phase should be reported to the user as a
+/// cancellation (exit 130) rather than a failure (exit 1).
+///
+/// A cancelled token on its own does not mean SIGINT. The parallel s3-to-stdio
+/// workers also cancel the pipeline token to stop their peers when a chunk GET
+/// or a stdout write fails, so reading the token alone reported exit 130 for a
+/// failed download and suppressed the error message entirely — while the same
+/// failure on the serial path exited 1 with the cause logged.
+///
+/// The transfer result is the authoritative signal: a genuine SIGINT surfaces
+/// as `S3syncError::Cancelled` (possibly wrapped in `.context()`), and anything
+/// else is a real failure that must be reported as one.
+fn is_user_cancellation(
+    token_cancelled: bool,
+    transfer_result: &Result<s3util_rs::transfer::TransferOutcome>,
+) -> bool {
+    token_cancelled
+        && transfer_result
+            .as_ref()
+            .err()
+            .is_none_or(s3util_rs::types::error::is_cancelled_error)
 }
 
 fn get_path_strings(source: &StoragePath, target: &StoragePath) -> (String, String) {
@@ -637,7 +663,13 @@ pub(super) fn extract_keys(config: &Config) -> Result<(String, String)> {
             let p = path.clone();
             // If target is a directory (existing dir or ends with separator),
             // append the source object's basename — like `aws s3 cp s3://bucket/key .`
-            if p.is_dir() || p.to_string_lossy().ends_with(std::path::MAIN_SEPARATOR) {
+            // The separator test must accept '/' on Windows too, so that `out/`
+            // resolves to `out/<basename>` rather than staying the literal key
+            // `out/`, which the storage layer would treat as a directory and
+            // silently write nothing for. (Upstream calls
+            // fs_util::has_trailing_separator, introduced after 1.7.1;
+            // is_key_a_directory is the same trailing-separator test.)
+            if p.is_dir() || fs_util::is_key_a_directory(&p.to_string_lossy()) {
                 p.join(&source_basename).to_string_lossy().to_string()
             } else {
                 p.to_string_lossy().to_string()
@@ -972,5 +1004,76 @@ mod tests {
         ]);
         let (_, tgt) = extract_keys(&config).unwrap();
         assert!(tgt.ends_with("object.bin"), "target was: {tgt}");
+    }
+
+    /// Same as above but with a forward slash instead of the platform separator.
+    /// Windows accepts `/` as a separator, and the storage layer treats a
+    /// trailing `/` as a directory on every platform — so key resolution must
+    /// append the basename here too. Leaving the key as the literal `out/` made
+    /// the storage layer skip the write entirely and report success.
+    #[test]
+    fn extract_keys_s3_to_local_forward_slash_target_appends_basename() {
+        let tmp = TempDir::new();
+        let target_arg = format!("{}/", tmp.path().to_string_lossy());
+        let config = build_config(vec![
+            "s3util",
+            "cp",
+            "s3://b/remote/object.bin",
+            target_arg.as_str(),
+        ]);
+        let (_, tgt) = extract_keys(&config).unwrap();
+        assert!(
+            tgt.ends_with("object.bin"),
+            "forward-slash directory target must resolve to <dir>/<basename>, got: {tgt}"
+        );
+        assert!(
+            !fs_util::is_key_a_directory(&tgt),
+            "resolved key must not still look like a directory to the storage layer: {tgt}"
+        );
+    }
+
+    /// Only a genuine SIGINT may be reported as a cancellation. The parallel
+    /// s3-to-stdio workers cancel the same token to stop their peers after a
+    /// chunk GET or stdout write fails; reporting that as exit 130 hid the
+    /// error message and disagreed with the serial path, which exits 1.
+    #[test]
+    fn worker_failure_that_cancels_the_token_is_not_user_cancellation() {
+        use anyhow::Context;
+        use s3util_rs::transfer::TransferOutcome;
+        use s3util_rs::types::error::S3syncError;
+
+        // A real failure that also cancelled the token => a failure, not 130.
+        let failed: Result<TransferOutcome> = Err(anyhow!("failed to download chunk: broken pipe"));
+        assert!(
+            !is_user_cancellation(true, &failed),
+            "a transfer error must be reported as a failure even though the \
+             worker cancelled the token to stop its peers"
+        );
+
+        // The same error wrapped in context must still be treated as a failure.
+        let wrapped: Result<TransferOutcome> = Err(anyhow!("connection reset"))
+            .context("failed to download chunk: s3://b/k bytes=0-8388607");
+        assert!(!is_user_cancellation(true, &wrapped));
+
+        // A genuine SIGINT surfaces as S3syncError::Cancelled => exit 130.
+        let cancelled: Result<TransferOutcome> = Err(anyhow!(S3syncError::Cancelled));
+        assert!(is_user_cancellation(true, &cancelled));
+
+        // ...including when it is wrapped in context on the way up.
+        let cancelled_wrapped: Result<TransferOutcome> =
+            Err(anyhow!(S3syncError::Cancelled)).context("failed to download source object: k");
+        assert!(is_user_cancellation(true, &cancelled_wrapped));
+
+        // Cancelled token with a successful transfer (SIGINT observed after the
+        // body completed) is still a cancellation.
+        assert!(is_user_cancellation(true, &Ok(TransferOutcome::default())));
+
+        // An un-cancelled token is never a cancellation, whatever the result.
+        assert!(!is_user_cancellation(
+            false,
+            &Ok(TransferOutcome::default())
+        ));
+        let e: Result<TransferOutcome> = Err(anyhow!("some failure"));
+        assert!(!is_user_cancellation(false, &e));
     }
 }

--- a/src/util_bin/cli/mv.rs
+++ b/src/util_bin/cli/mv.rs
@@ -1,17 +1,100 @@
 // Vendored from s3util-rs@1.1.0
 //   src/bin/s3util/cli/mv.rs
 // Adjustments: stripped #[cfg(test)] mod tests; rewrote crate::cli → super
+// Includes the self-move guard ported from s3util-rs PR#25 (post-1.7.1):
+//   check_not_self_move rejects `mv` onto the same S3 object before the copy
+//   runs (copy-then-delete would destroy the object on an unversioned bucket).
 
 use anyhow::{Result, anyhow};
 use tracing::{error, info};
 
 use s3util_rs::Config;
+use s3util_rs::types::StoragePath;
 
-use super::{CopyPhase, ExitStatus, run_copy_phase};
+use super::{CopyPhase, ExitStatus, extract_keys, run_copy_phase};
 
 pub async fn run_mv(config: Config) -> Result<ExitStatus> {
+    check_not_self_move(&config)?;
+
     let phase = run_copy_phase(config.clone()).await?;
     apply_mv_decision_tree(config, phase).await
+}
+
+/// Reject `mv` when source and target resolve to the same S3 object.
+///
+/// `mv` is copy-then-delete, so a self-move deletes what the copy just wrote.
+/// On an unversioned bucket that destroys the object outright and still exits 0;
+/// on a versioned bucket it survives only because the delete happens to target
+/// the pre-copy version. The target key is resolved the same way the transfer
+/// resolves it, so directory-style targets are caught too:
+/// `mv s3://b/dir/file s3://b/dir/` resolves to the source key itself.
+///
+/// Two escapes keep legitimate moves working:
+/// - Different source/target endpoints are different services, where equal
+///   bucket and key names still name two distinct objects (e.g. migrating
+///   between two MinIO instances that share a bucket name). Credentials and
+///   profiles are deliberately NOT compared: two profiles can address the
+///   same object, and the guard must still fire then.
+/// - An explicit `--source-version-id` turns the same-key `mv` into "promote
+///   that version": the copy publishes it as the newest version and the
+///   delete removes only the copied version, so nothing is destroyed. The
+///   `null` pseudo-version is excluded — on an unversioned or suspended
+///   bucket the copy overwrites the `null` version itself, and the delete
+///   would then remove the object the copy just wrote.
+///
+/// Checked before the copy runs, so nothing is transferred or deleted.
+fn check_not_self_move(config: &Config) -> Result<()> {
+    let (
+        StoragePath::S3 {
+            bucket: source_bucket,
+            ..
+        },
+        StoragePath::S3 {
+            bucket: target_bucket,
+            ..
+        },
+    ) = (&config.source, &config.target)
+    else {
+        return Ok(());
+    };
+
+    if source_bucket != target_bucket {
+        return Ok(());
+    }
+
+    // Endpoint comparison is textual and best-effort: two spellings of the
+    // same endpoint make the guard err on the side of allowing the move.
+    let source_endpoint = config
+        .source_client_config
+        .as_ref()
+        .and_then(|c| c.endpoint_url.as_deref());
+    let target_endpoint = config
+        .target_client_config
+        .as_ref()
+        .and_then(|c| c.endpoint_url.as_deref());
+    if source_endpoint != target_endpoint {
+        return Ok(());
+    }
+
+    let (source_key, target_key) = extract_keys(config)?;
+    if source_key != target_key {
+        return Ok(());
+    }
+
+    if config
+        .version_id
+        .as_deref()
+        .is_some_and(|version_id| version_id != "null")
+    {
+        return Ok(());
+    }
+
+    Err(anyhow!(
+        "cannot mv an object onto itself: source and target both resolve to \
+         s3://{source_bucket}/{source_key}. mv is copy-then-delete, so this \
+         would delete the object it just wrote; use cp to rewrite an object \
+         in place"
+    ))
 }
 
 async fn apply_mv_decision_tree(config: Config, phase: CopyPhase) -> Result<ExitStatus> {
@@ -103,14 +186,19 @@ mod tests {
     use aws_sdk_s3::operation::put_object::PutObjectOutput;
     use aws_sdk_s3::operation::put_object_tagging::PutObjectTaggingOutput;
     use aws_sdk_s3::types::{ChecksumMode, ObjectPart, Tagging};
+    use aws_smithy_types::checksum_config::RequestChecksumCalculation;
     use leaky_bucket::RateLimiter;
-    use s3util_rs::config::TransferConfig;
+    use s3util_rs::config::{CLITimeoutConfig, ClientConfig, RetryConfig, TransferConfig};
     use s3util_rs::storage::{Storage, StorageTrait};
     use s3util_rs::transfer::TransferOutcome;
     use s3util_rs::types::token::{PipelineCancellationToken, create_pipeline_cancellation_token};
-    use s3util_rs::types::{ObjectChecksum, SseCustomerKey, StoragePath, SyncStatistics};
+    use s3util_rs::types::{
+        ClientConfigLocation, ObjectChecksum, S3Credentials, SseCustomerKey, StoragePath,
+        SyncStatistics,
+    };
     use std::path::PathBuf;
     use std::sync::{Arc, Mutex};
+    use tokio::sync::Semaphore;
 
     type DeleteCall = (String, Option<String>);
 
@@ -353,6 +441,264 @@ mod tests {
             cancelled,
             has_warning,
         }
+    }
+
+    /// `mv s3://b/k s3://b/k` is copy-then-delete onto the same object, which
+    /// destroys it on an unversioned bucket. It must be rejected before the
+    /// copy runs.
+    #[test]
+    fn self_move_identical_keys_is_rejected() {
+        let mut config = minimal_config();
+        config.source = StoragePath::S3 {
+            bucket: "b".to_string(),
+            prefix: "dir/file.txt".to_string(),
+        };
+        config.target = StoragePath::S3 {
+            bucket: "b".to_string(),
+            prefix: "dir/file.txt".to_string(),
+        };
+
+        let err = check_not_self_move(&config).expect_err("self-move must be rejected");
+        assert!(
+            err.to_string().contains("onto itself"),
+            "error must explain the self-move, got: {err}"
+        );
+    }
+
+    /// The directory-style form resolves to the source key by appending the
+    /// basename, so it is the same data-loss case spelled differently.
+    #[test]
+    fn self_move_via_directory_style_target_is_rejected() {
+        let mut config = minimal_config();
+        config.source = StoragePath::S3 {
+            bucket: "b".to_string(),
+            prefix: "dir/file.txt".to_string(),
+        };
+        config.target = StoragePath::S3 {
+            bucket: "b".to_string(),
+            prefix: "dir/".to_string(),
+        };
+
+        assert!(
+            check_not_self_move(&config).is_err(),
+            "`mv s3://b/dir/file.txt s3://b/dir/` resolves to the source key and must be rejected"
+        );
+    }
+
+    /// `mv s3://b/file.txt s3://b` — a bucket-only target resolves by appending
+    /// the source basename, which for a root-level source is the source key.
+    #[test]
+    fn self_move_via_bucket_only_target_is_rejected() {
+        let mut config = minimal_config();
+        config.source = StoragePath::S3 {
+            bucket: "b".to_string(),
+            prefix: "file.txt".to_string(),
+        };
+        config.target = StoragePath::S3 {
+            bucket: "b".to_string(),
+            prefix: String::new(),
+        };
+
+        assert!(
+            check_not_self_move(&config).is_err(),
+            "`mv s3://b/file.txt s3://b` resolves to the source key and must be rejected"
+        );
+    }
+
+    /// The same bucket-only target is a legitimate move when the source lives in
+    /// a subdirectory — it relocates the object to the bucket root.
+    #[test]
+    fn bucket_only_target_from_subdirectory_is_allowed() {
+        let mut config = minimal_config();
+        config.source = StoragePath::S3 {
+            bucket: "b".to_string(),
+            prefix: "dir/file.txt".to_string(),
+        };
+        config.target = StoragePath::S3 {
+            bucket: "b".to_string(),
+            prefix: String::new(),
+        };
+
+        assert!(
+            check_not_self_move(&config).is_ok(),
+            "moving dir/file.txt to the bucket root is a genuine move"
+        );
+    }
+
+    #[test]
+    fn genuine_moves_are_allowed() {
+        // Same bucket, different key.
+        let mut config = minimal_config();
+        config.source = StoragePath::S3 {
+            bucket: "b".to_string(),
+            prefix: "a.txt".to_string(),
+        };
+        config.target = StoragePath::S3 {
+            bucket: "b".to_string(),
+            prefix: "b.txt".to_string(),
+        };
+        assert!(check_not_self_move(&config).is_ok());
+
+        // Same key, different bucket.
+        config.target = StoragePath::S3 {
+            bucket: "other".to_string(),
+            prefix: "a.txt".to_string(),
+        };
+        assert!(check_not_self_move(&config).is_ok());
+
+        // Directory-style target that resolves to a different key.
+        config.target = StoragePath::S3 {
+            bucket: "b".to_string(),
+            prefix: "dir/".to_string(),
+        };
+        assert!(check_not_self_move(&config).is_ok());
+
+        // Non-S3 target is never a self-move.
+        config.target = StoragePath::Local(PathBuf::from("/tmp/a.txt"));
+        assert!(check_not_self_move(&config).is_ok());
+
+        // Stdio on either side is never a self-move (rejected earlier by clap,
+        // but the guard must not misfire or panic on it).
+        config.target = StoragePath::Stdio;
+        assert!(check_not_self_move(&config).is_ok());
+        config.source = StoragePath::Stdio;
+        config.target = StoragePath::S3 {
+            bucket: "b".to_string(),
+            prefix: "a.txt".to_string(),
+        };
+        assert!(check_not_self_move(&config).is_ok());
+
+        // Local source to S3 target — different storage kinds, never a self-move.
+        config.source = StoragePath::Local(PathBuf::from("/tmp/a.txt"));
+        assert!(check_not_self_move(&config).is_ok());
+    }
+
+    /// A `ClientConfig` that matters to `check_not_self_move` only through its
+    /// `endpoint_url`; every other field is a neutral default.
+    fn client_config_with_endpoint(endpoint_url: Option<&str>) -> ClientConfig {
+        ClientConfig {
+            client_config_location: ClientConfigLocation {
+                aws_config_file: None,
+                aws_shared_credentials_file: None,
+            },
+            credential: S3Credentials::FromEnvironment,
+            region: None,
+            endpoint_url: endpoint_url.map(String::from),
+            force_path_style: false,
+            accelerate: false,
+            request_payer: None,
+            retry_config: RetryConfig {
+                aws_max_attempts: 1,
+                initial_backoff_milliseconds: 0,
+            },
+            cli_timeout_config: CLITimeoutConfig {
+                operation_timeout_milliseconds: None,
+                operation_attempt_timeout_milliseconds: None,
+                connect_timeout_milliseconds: None,
+                read_timeout_milliseconds: None,
+            },
+            disable_stalled_stream_protection: false,
+            request_checksum_calculation: RequestChecksumCalculation::WhenRequired,
+            parallel_upload_semaphore: Arc::new(Semaphore::new(1)),
+        }
+    }
+
+    /// Source and target spelling the same object: `s3://b/dir/file.txt` on
+    /// both sides.
+    fn self_move_shaped_config() -> Config {
+        let mut config = minimal_config();
+        config.source = StoragePath::S3 {
+            bucket: "b".to_string(),
+            prefix: "dir/file.txt".to_string(),
+        };
+        config.target = StoragePath::S3 {
+            bucket: "b".to_string(),
+            prefix: "dir/file.txt".to_string(),
+        };
+        config
+    }
+
+    /// The same bucket and key on two different endpoints are two distinct
+    /// objects — e.g. migrating between two MinIO instances that share a
+    /// bucket name — so the guard must not fire across endpoints.
+    #[test]
+    fn same_names_on_different_endpoints_are_not_a_self_move() {
+        let mut config = self_move_shaped_config();
+        config.source_client_config =
+            Some(client_config_with_endpoint(Some("http://old-storage:9000")));
+        config.target_client_config =
+            Some(client_config_with_endpoint(Some("http://new-storage:9000")));
+
+        assert!(
+            check_not_self_move(&config).is_ok(),
+            "equal bucket/key names on two different endpoints are two different objects"
+        );
+    }
+
+    /// One side on AWS (no endpoint override), the other on a custom endpoint:
+    /// different services as well.
+    #[test]
+    fn same_names_with_one_custom_endpoint_are_not_a_self_move() {
+        let mut config = self_move_shaped_config();
+        config.source_client_config = Some(client_config_with_endpoint(None));
+        config.target_client_config = Some(client_config_with_endpoint(Some("http://minio:9000")));
+
+        assert!(check_not_self_move(&config).is_ok());
+    }
+
+    /// Equal explicit endpoints are the same service, so the guard must still
+    /// fire — the endpoint escape must not swallow the actual data-loss case.
+    /// Credentials are deliberately not consulted: two different profiles can
+    /// address the same object.
+    #[test]
+    fn self_move_on_the_same_explicit_endpoint_is_still_rejected() {
+        let mut config = self_move_shaped_config();
+        config.source_client_config = Some(client_config_with_endpoint(Some("http://minio:9000")));
+        config.target_client_config = Some(client_config_with_endpoint(Some("http://minio:9000")));
+
+        assert!(check_not_self_move(&config).is_err());
+    }
+
+    /// An explicit `--source-version-id` makes the same-key mv the "promote a
+    /// version" operation: the copy publishes that version as the newest one
+    /// and the delete removes only the copied version
+    /// (`apply_mv_decision_tree` resolves the delete's version-id from
+    /// `config.version_id` first), so nothing is destroyed.
+    #[test]
+    fn self_move_with_explicit_version_id_is_allowed_as_version_promotion() {
+        let mut config = self_move_shaped_config();
+        config.version_id = Some("3sL4kqtJlcpXroDTDmJ+rmSpXd3dIbrHY".to_string());
+
+        assert!(check_not_self_move(&config).is_ok());
+    }
+
+    /// ...except the `null` pseudo-version: on an unversioned or suspended
+    /// bucket the copy overwrites the `null` version itself, so the delete
+    /// would remove the object the copy just wrote — the original hazard.
+    #[test]
+    fn self_move_with_null_pseudo_version_is_still_rejected() {
+        let mut config = self_move_shaped_config();
+        config.version_id = Some("null".to_string());
+
+        assert!(check_not_self_move(&config).is_err());
+    }
+
+    /// The guard must be wired into `run_mv` itself, not merely exist as a
+    /// helper: a self-move config errors out of `run_mv` before
+    /// `run_copy_phase` builds any client or touches the network. (The tests
+    /// above call `check_not_self_move` directly; this one would keep passing
+    /// only while `run_mv` still invokes it first.)
+    #[tokio::test]
+    async fn run_mv_rejects_self_move_before_any_transfer() {
+        let config = self_move_shaped_config();
+
+        let err = Box::pin(run_mv(config))
+            .await
+            .expect_err("run_mv must reject a self-move before transferring");
+        assert!(
+            err.to_string().contains("onto itself"),
+            "error must be the self-move rejection, got: {err}"
+        );
     }
 
     #[tokio::test]

--- a/src/util_bin/cli/put_bucket_accelerate_configuration.rs
+++ b/src/util_bin/cli/put_bucket_accelerate_configuration.rs
@@ -1,8 +1,13 @@
 // Vendored from s3util-rs@1.3.0
 //   src/bin/s3util/cli/put_bucket_accelerate_configuration.rs
-// Adjustments: no tests stripped; rewrote crate::cli → super
+// Adjustments: no tests stripped; rewrote crate::cli → super;
+//              replaced the process-exiting `validate_state_flag()` call
+//              with the non-exiting `check_state_flag` invoked from
+//              dispatch.rs (a `process::exit(2)` would kill a whole
+//              batch-run instead of failing one line).
 use anyhow::Result;
 use aws_sdk_s3::types::AccelerateConfiguration;
+use clap::CommandFactory;
 use tracing::info;
 
 use s3util_rs::config::ClientConfig;
@@ -20,8 +25,8 @@ pub async fn run_put_bucket_accelerate_configuration(
     args: PutBucketAccelerateConfigurationArgs,
     client_config: ClientConfig,
 ) -> Result<()> {
-    args.validate_state_flag();
-
+    // --enabled/--suspended presence is enforced by `check_state_flag`,
+    // which dispatch.rs runs before invoking this runner.
     let bucket = args
         .bucket_name()
         .map_err(|e| anyhow::anyhow!("{}", e.trim_end()))?;
@@ -45,4 +50,57 @@ pub async fn run_put_bucket_accelerate_configuration(
         "Bucket Transfer Acceleration set."
     );
     Ok(())
+}
+
+/// Non-exiting replacement for upstream's `validate_state_flag`, whose
+/// `clap::Error::exit()` (`std::process::exit(2)`) cannot be contained by
+/// batch-run's per-line error handling. dispatch.rs calls this before the
+/// runner, prints the error, and returns exit code 2 — same message and
+/// code as upstream, without terminating the process.
+pub fn check_state_flag(args: &PutBucketAccelerateConfigurationArgs) -> Result<(), clap::Error> {
+    if !args.enabled && !args.suspended {
+        let mut cmd = PutBucketAccelerateConfigurationArgs::command();
+        return Err(cmd.error(
+            clap::error::ErrorKind::MissingRequiredArgument,
+            "one of --enabled or --suspended must be specified",
+        ));
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use clap::Parser;
+
+    fn parse(argv: &[&str]) -> PutBucketAccelerateConfigurationArgs {
+        PutBucketAccelerateConfigurationArgs::try_parse_from(argv).expect("args should parse")
+    }
+
+    #[test]
+    fn check_state_flag_rejects_neither_flag() {
+        let args = parse(&["put-bucket-accelerate-configuration", "s3://b"]);
+        let err = check_state_flag(&args).expect_err("neither flag must be rejected");
+        assert_eq!(err.kind(), clap::error::ErrorKind::MissingRequiredArgument);
+        assert!(
+            err.to_string()
+                .contains("one of --enabled or --suspended must be specified")
+        );
+    }
+
+    #[test]
+    fn check_state_flag_accepts_enabled() {
+        let args = parse(&["put-bucket-accelerate-configuration", "s3://b", "--enabled"]);
+        assert!(check_state_flag(&args).is_ok());
+    }
+
+    #[test]
+    fn check_state_flag_accepts_suspended() {
+        let args = parse(&[
+            "put-bucket-accelerate-configuration",
+            "s3://b",
+            "--suspended",
+        ]);
+        assert!(check_state_flag(&args).is_ok());
+    }
 }

--- a/src/util_bin/cli/put_bucket_lifecycle_configuration.rs
+++ b/src/util_bin/cli/put_bucket_lifecycle_configuration.rs
@@ -1,6 +1,13 @@
 // Vendored from s3util-rs@1.1.0
 //   src/bin/s3util/cli/put_bucket_lifecycle_configuration.rs
 // Adjustments: no tests stripped; rewrote crate::cli → super
+// Includes an adapted fix from s3util-rs PR#25 (post-1.7.1): a top-level
+// `TransitionDefaultMinimumObjectSize` in the input JSON is rejected with
+// guidance instead of being silently dropped. Upstream implements this via
+// `deny_unknown_fields` on the input structs plus a
+// `--transition-default-minimum-object-size` flag; neither exists in the
+// released 1.7.1 library, so the vendored runner checks the raw JSON itself
+// (the flag pointer in the upstream hint is omitted until the library ships).
 use anyhow::{Context, Result};
 use tracing::info;
 
@@ -38,8 +45,8 @@ pub async fn run_put_bucket_lifecycle_configuration(
             .with_context(|| format!("reading lifecycle configuration from {config_arg}"))?
     };
 
-    let parsed: LifecycleConfigurationJson =
-        serde_json::from_str(&body).with_context(|| format!("parsing JSON from {config_arg}"))?;
+    let parsed = parse_lifecycle_configuration(&body)
+        .with_context(|| format!("parsing JSON from {config_arg}"))?;
     let cfg = parsed.into_sdk()?;
 
     let client = client_config.create_client().await;
@@ -50,4 +57,76 @@ pub async fn run_put_bucket_lifecycle_configuration(
     api::put_bucket_lifecycle_configuration(&client, &bucket, cfg).await?;
     info!(bucket = %bucket, "Bucket lifecycle configuration set.");
     Ok(())
+}
+
+/// Parses the lifecycle configuration JSON body.
+///
+/// `get-bucket-lifecycle-configuration` reports `TransitionDefaultMinimumObjectSize`
+/// at the top level (matching `aws s3api`), but S3 accepts it only as a request
+/// parameter, never inside the configuration document — so feeding the get
+/// output back into put must not carry it along. The 1.7.1 library's
+/// `LifecycleConfigurationJson` silently ignores unknown fields, which would
+/// drop the value and reset the bucket to S3's default of
+/// `all_storage_classes_128K`. Reject it up front instead.
+fn parse_lifecycle_configuration(body: &str) -> Result<LifecycleConfigurationJson> {
+    let value: serde_json::Value = serde_json::from_str(body)?;
+    if value
+        .as_object()
+        .is_some_and(|o| o.contains_key("TransitionDefaultMinimumObjectSize"))
+    {
+        anyhow::bail!(
+            "`TransitionDefaultMinimumObjectSize` is a request parameter, not part of the \
+             lifecycle configuration document: remove it from the JSON (S3 then applies its \
+             default of `all_storage_classes_128K`)"
+        );
+    }
+    serde_json::from_value(value).map_err(anyhow::Error::from)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn valid_rules_document_parses() {
+        let body = r#"{"Rules": [{"ID": "r1", "Status": "Enabled",
+            "Expiration": {"Days": 30}, "Filter": {"Prefix": ""}}]}"#;
+        assert!(parse_lifecycle_configuration(body).is_ok());
+    }
+
+    /// Feeding `get-bucket-lifecycle-configuration` output (which carries
+    /// `TransitionDefaultMinimumObjectSize` at the top level) into put must
+    /// fail with guidance, not silently drop the value — dropping it would
+    /// reset a bucket set to `varies_by_storage_class` back to S3's default.
+    #[test]
+    fn get_output_fed_back_into_put_is_rejected_with_guidance() {
+        let body = r#"{"Rules": [{"ID": "r1", "Status": "Enabled",
+            "Expiration": {"Days": 30}, "Filter": {"Prefix": ""}}],
+            "TransitionDefaultMinimumObjectSize": "all_storage_classes_128K"}"#;
+        let err = parse_lifecycle_configuration(body).unwrap_err();
+        assert!(
+            format!("{err:#}").contains("request parameter"),
+            "error must explain the field is a request parameter; got: {err:#}"
+        );
+    }
+
+    /// Other unknown fields keep the 1.7.1 library behavior (ignored by
+    /// serde), without the unrelated guidance firing.
+    #[test]
+    fn other_unknown_fields_do_not_trigger_the_guidance() {
+        let body = r#"{"Rules": [], "Bogus": 1}"#;
+        let result = parse_lifecycle_configuration(body);
+        assert!(
+            result.is_ok(),
+            "unknown fields other than TransitionDefaultMinimumObjectSize keep \
+             the 1.7.1 ignore behavior; got: {:?}",
+            result.err()
+        );
+    }
+
+    /// Invalid JSON still surfaces as a serde error.
+    #[test]
+    fn invalid_json_is_a_parse_error() {
+        assert!(parse_lifecycle_configuration("{not json").is_err());
+    }
 }

--- a/src/util_bin/cli/put_bucket_request_payment.rs
+++ b/src/util_bin/cli/put_bucket_request_payment.rs
@@ -1,8 +1,13 @@
 // Vendored from s3util-rs@1.3.0
 //   src/bin/s3util/cli/put_bucket_request_payment.rs
-// Adjustments: no tests stripped; rewrote crate::cli → super
+// Adjustments: no tests stripped; rewrote crate::cli → super;
+//              replaced the process-exiting `validate_state_flag()` call
+//              with the non-exiting `check_state_flag` invoked from
+//              dispatch.rs (a `process::exit(2)` would kill a whole
+//              batch-run instead of failing one line).
 use anyhow::Result;
 use aws_sdk_s3::types::RequestPaymentConfiguration;
+use clap::CommandFactory;
 use tracing::info;
 
 use s3util_rs::config::ClientConfig;
@@ -20,8 +25,8 @@ pub async fn run_put_bucket_request_payment(
     args: PutBucketRequestPaymentArgs,
     client_config: ClientConfig,
 ) -> Result<()> {
-    args.validate_state_flag();
-
+    // --requester/--bucket-owner presence is enforced by `check_state_flag`,
+    // which dispatch.rs runs before invoking this runner.
     let bucket = args
         .bucket_name()
         .map_err(|e| anyhow::anyhow!("{}", e.trim_end()))?;
@@ -45,4 +50,53 @@ pub async fn run_put_bucket_request_payment(
         "Bucket request payment set."
     );
     Ok(())
+}
+
+/// Non-exiting replacement for upstream's `validate_state_flag`, whose
+/// `clap::Error::exit()` (`std::process::exit(2)`) cannot be contained by
+/// batch-run's per-line error handling. dispatch.rs calls this before the
+/// runner, prints the error, and returns exit code 2 — same message and
+/// code as upstream, without terminating the process.
+pub fn check_state_flag(args: &PutBucketRequestPaymentArgs) -> Result<(), clap::Error> {
+    if !args.requester && !args.bucket_owner {
+        let mut cmd = PutBucketRequestPaymentArgs::command();
+        return Err(cmd.error(
+            clap::error::ErrorKind::MissingRequiredArgument,
+            "one of --requester or --bucket-owner must be specified",
+        ));
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use clap::Parser;
+
+    fn parse(argv: &[&str]) -> PutBucketRequestPaymentArgs {
+        PutBucketRequestPaymentArgs::try_parse_from(argv).expect("args should parse")
+    }
+
+    #[test]
+    fn check_state_flag_rejects_neither_flag() {
+        let args = parse(&["put-bucket-request-payment", "s3://b"]);
+        let err = check_state_flag(&args).expect_err("neither flag must be rejected");
+        assert_eq!(err.kind(), clap::error::ErrorKind::MissingRequiredArgument);
+        assert!(
+            err.to_string()
+                .contains("one of --requester or --bucket-owner must be specified")
+        );
+    }
+
+    #[test]
+    fn check_state_flag_accepts_requester() {
+        let args = parse(&["put-bucket-request-payment", "s3://b", "--requester"]);
+        assert!(check_state_flag(&args).is_ok());
+    }
+
+    #[test]
+    fn check_state_flag_accepts_bucket_owner() {
+        let args = parse(&["put-bucket-request-payment", "s3://b", "--bucket-owner"]);
+        assert!(check_state_flag(&args).is_ok());
+    }
 }

--- a/src/util_bin/cli/put_bucket_versioning.rs
+++ b/src/util_bin/cli/put_bucket_versioning.rs
@@ -1,7 +1,12 @@
 // Vendored from s3util-rs@1.1.0
 //   src/bin/s3util/cli/put_bucket_versioning.rs
-// Adjustments: no tests stripped; rewrote crate::cli → super
+// Adjustments: no tests stripped; rewrote crate::cli → super;
+//              replaced the process-exiting `validate_state_flag()` call
+//              with the non-exiting `check_state_flag` invoked from
+//              dispatch.rs (a `process::exit(2)` would kill a whole
+//              batch-run instead of failing one line).
 use anyhow::Result;
+use clap::CommandFactory;
 use tracing::info;
 
 use s3util_rs::config::ClientConfig;
@@ -17,10 +22,8 @@ pub async fn run_put_bucket_versioning(
     args: PutBucketVersioningArgs,
     client_config: ClientConfig,
 ) -> Result<()> {
-    // Enforce that exactly one of --enabled / --suspended was given.
-    // This exits with code 2 if neither flag is present (matches clap convention).
-    args.validate_state_flag();
-
+    // --enabled/--suspended presence is enforced by `check_state_flag`,
+    // which dispatch.rs runs before invoking this runner.
     let bucket = args
         .bucket_name()
         .map_err(|e| anyhow::anyhow!("{}", e.trim_end()))?;
@@ -33,4 +36,53 @@ pub async fn run_put_bucket_versioning(
     api::put_bucket_versioning(&client, &bucket, status.clone()).await?;
     info!(bucket = %bucket, status = %status.as_str(), "Bucket versioning set.");
     Ok(())
+}
+
+/// Non-exiting replacement for upstream's `validate_state_flag`, whose
+/// `clap::Error::exit()` (`std::process::exit(2)`) cannot be contained by
+/// batch-run's per-line error handling. dispatch.rs calls this before the
+/// runner, prints the error, and returns exit code 2 — same message and
+/// code as upstream, without terminating the process.
+pub fn check_state_flag(args: &PutBucketVersioningArgs) -> Result<(), clap::Error> {
+    if !args.enabled && !args.suspended {
+        let mut cmd = PutBucketVersioningArgs::command();
+        return Err(cmd.error(
+            clap::error::ErrorKind::MissingRequiredArgument,
+            "one of --enabled or --suspended must be specified",
+        ));
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use clap::Parser;
+
+    fn parse(argv: &[&str]) -> PutBucketVersioningArgs {
+        PutBucketVersioningArgs::try_parse_from(argv).expect("args should parse")
+    }
+
+    #[test]
+    fn check_state_flag_rejects_neither_flag() {
+        let args = parse(&["put-bucket-versioning", "s3://b"]);
+        let err = check_state_flag(&args).expect_err("neither flag must be rejected");
+        assert_eq!(err.kind(), clap::error::ErrorKind::MissingRequiredArgument);
+        assert!(
+            err.to_string()
+                .contains("one of --enabled or --suspended must be specified")
+        );
+    }
+
+    #[test]
+    fn check_state_flag_accepts_enabled() {
+        let args = parse(&["put-bucket-versioning", "s3://b", "--enabled"]);
+        assert!(check_state_flag(&args).is_ok());
+    }
+
+    #[test]
+    fn check_state_flag_accepts_suspended() {
+        let args = parse(&["put-bucket-versioning", "s3://b", "--suspended"]);
+        assert!(check_state_flag(&args).is_ok());
+    }
 }

--- a/src/util_bin/tracing_init.rs
+++ b/src/util_bin/tracing_init.rs
@@ -270,4 +270,20 @@ mod tests {
             disable_color_tracing: true,
         });
     }
+
+    /// Drive the real `PipeSafeWriter` through its non-BrokenPipe arms. The
+    /// BrokenPipe arms need stderr to be an actually-closed pipe and are
+    /// exercised at process level by the e2e suites. Ported from s3util-rs
+    /// PR#25 (post-1.7.1).
+    #[test]
+    fn pipe_safe_writer_write_and_flush_pass_through() {
+        use std::io::Write;
+
+        let mut writer = PipeSafeWriter;
+        let written = writer
+            .write(b"")
+            .expect("empty write to stderr must pass through");
+        assert_eq!(written, 0);
+        writer.flush().expect("flush to stderr must pass through");
+    }
 }

--- a/tests/batch_run.rs
+++ b/tests/batch_run.rs
@@ -1305,3 +1305,106 @@ fn batch_run_script_file_executes_lines() {
         .success()
         .stderr(predicate::str::contains("2 succeeded, 0 failed"));
 }
+
+// ---- inline-credential redaction in per-line logs ----
+//
+// A batch-run line may legally carry a credential inline (e.g.
+// `--target-secret-access-key <value>`). batch-run echoes each line's raw
+// text into per-line log events; without masking, that secret is written to
+// stderr (and to `--json-tracing` JSON) on any non-success outcome — visible
+// at the default verbosity. `redact::redact_secrets` masks the value of every
+// known secret flag before logging. `RUST_LOG` is cleared so the default
+// s7cmd tracing filter applies deterministically.
+
+/// Invalid (parse-error) line → logged at error level, visible at the default
+/// verbosity. The inline secret must be masked to `****`, not echoed.
+#[test]
+fn batch_run_masks_inline_secret_in_invalid_line_log() {
+    let secret = "wJalrXUtnFEMIsupersecretVALUE0001";
+    let assert = Command::cargo_bin("s7cmd")
+        .unwrap()
+        .env_remove("RUST_LOG")
+        .args(["batch-run", "--continue-on-error", "-"])
+        .write_stdin(format!(
+            "head-bucket --target-access-key AKIAEXAMPLEID --target-secret-access-key {secret} --bogus-unknown-flag s3://b\n"
+        ))
+        .assert()
+        .failure();
+    let stderr = String::from_utf8(assert.get_output().stderr.clone()).unwrap();
+    assert!(
+        !stderr.contains(secret),
+        "secret leaked into invalid-line log: {stderr}"
+    );
+    assert!(
+        stderr.contains("****"),
+        "expected redaction placeholder: {stderr}"
+    );
+    // The line stays identifiable — the subcommand token survives redaction.
+    assert!(
+        stderr.contains("head-bucket"),
+        "command context lost: {stderr}"
+    );
+}
+
+/// `--check-format` path → the invalid line is logged at error level; the
+/// inline secret must be masked there too.
+#[test]
+fn batch_run_check_format_masks_inline_secret() {
+    let secret = "wJalrXUtnFEMIsupersecretVALUE0002";
+    let assert = Command::cargo_bin("s7cmd")
+        .unwrap()
+        .env_remove("RUST_LOG")
+        .args(["batch-run", "--check-format", "-"])
+        .write_stdin(format!(
+            "head-bucket --target-access-key AKIAEXAMPLEID --target-secret-access-key {secret} --bogus-unknown-flag s3://b\n"
+        ))
+        .assert()
+        .failure();
+    let stderr = String::from_utf8(assert.get_output().stderr.clone()).unwrap();
+    assert!(
+        !stderr.contains(secret),
+        "secret leaked into check-format log: {stderr}"
+    );
+    assert!(
+        stderr.contains("****"),
+        "expected redaction placeholder: {stderr}"
+    );
+}
+
+/// A successfully dispatched line logged at info level (`-v`) must also mask
+/// an inline credential. `presign` signs locally (no network), so this runs
+/// offline and exercises the `log_start` / `log_end` success path.
+#[test]
+fn batch_run_masks_inline_secret_in_success_log() {
+    let secret = "wJalrXUtnFEMIsupersecretVALUE0003";
+    let assert = Command::cargo_bin("s7cmd")
+        .unwrap()
+        .env_remove("RUST_LOG")
+        .args(["batch-run", "-v", "-"])
+        .write_stdin(format!(
+            "presign s3://bucket/key --target-access-key AKIAEXAMPLEID --target-secret-access-key {secret} --target-region us-east-1\n"
+        ))
+        .assert()
+        .success();
+    let out = assert.get_output();
+    let stderr = String::from_utf8(out.stderr.clone()).unwrap();
+    let stdout = String::from_utf8(out.stdout.clone()).unwrap();
+    assert!(
+        !stderr.contains(secret),
+        "secret leaked into info-level log: {stderr}"
+    );
+    assert!(
+        stderr.contains("****"),
+        "expected redaction placeholder: {stderr}"
+    );
+    // The presigned URL is still produced on stdout, and it never carries the
+    // secret access key (only the access key id + signature).
+    assert!(
+        stdout.contains("X-Amz-Signature"),
+        "presigned URL expected on stdout: {stdout}"
+    );
+    assert!(
+        !stdout.contains(secret),
+        "secret must never appear in the presigned URL: {stdout}"
+    );
+}

--- a/tests/batch_run.rs
+++ b/tests/batch_run.rs
@@ -1263,3 +1263,45 @@ fn batch_run_state_flag_error_does_not_kill_batch() {
         "summary must still be printed: {stderr}"
     );
 }
+
+/// `--check-format` must surface an over-cap line as a per-line read error
+/// (structured `read_error` event) rather than silently stopping — the
+/// sync `check_format_lines` walker has its own read-error branch,
+/// separate from the executor paths.
+#[test]
+fn batch_run_check_format_oversized_line_reports_read_error() {
+    let long_line = format!("head-bucket s3://{}\n", "a".repeat(17 * 1024));
+    Command::cargo_bin("s7cmd")
+        .unwrap()
+        .args([
+            "batch-run",
+            "--check-format",
+            "--disable-color-tracing",
+            "-",
+        ])
+        .write_stdin(long_line)
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("line read error"))
+        .stderr(predicate::str::contains("read_error"));
+}
+
+/// Scripts can come from a real file, not just `-`/stdin — the file branch
+/// of `run_read_all` (open + BufReader + read_all) must behave identically
+/// to the stdin branch, including the summary.
+#[test]
+fn batch_run_script_file_executes_lines() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let script = dir.path().join("batch.txt");
+    std::fs::write(
+        &script,
+        "# comment\ncreate-bucket --dry-run s3://batch-file-a\ncreate-bucket --dry-run s3://batch-file-b\n",
+    )
+    .expect("write script");
+    Command::cargo_bin("s7cmd")
+        .unwrap()
+        .args(["batch-run", script.to_str().unwrap()])
+        .assert()
+        .success()
+        .stderr(predicate::str::contains("2 succeeded, 0 failed"));
+}

--- a/tests/batch_run.rs
+++ b/tests/batch_run.rs
@@ -1229,3 +1229,37 @@ fn batch_run_json_tracing_invalid_line_fields() {
         invalid["fields"]["reason"]
     );
 }
+
+/// A state-flag arg error inside a batch line must fail that line (exit 2)
+/// without killing the whole batch: upstream's validate_state_flag called
+/// process::exit(2), which bypassed per-line containment, skipped every
+/// later line, and suppressed the summary.
+#[test]
+fn batch_run_state_flag_error_does_not_kill_batch() {
+    let assert = Command::cargo_bin("s7cmd")
+        .unwrap()
+        .args(["batch-run", "--continue-on-error", "-"])
+        .write_stdin(
+            "put-bucket-versioning s3://example-bucket\n\
+             put-bucket-accelerate-configuration s3://example-bucket\n\
+             put-bucket-request-payment s3://example-bucket\n",
+        )
+        .assert()
+        .failure();
+    let stderr = String::from_utf8(assert.get_output().stderr.clone()).unwrap();
+    assert!(
+        stderr
+            .matches("one of --enabled or --suspended must be specified")
+            .count()
+            == 2,
+        "lines 1 and 2 must both report the state-flag error: {stderr}"
+    );
+    assert!(
+        stderr.contains("one of --requester or --bucket-owner must be specified"),
+        "line 3 must still run after earlier lines failed: {stderr}"
+    );
+    assert!(
+        stderr.contains("0 succeeded, 3 failed"),
+        "summary must still be printed: {stderr}"
+    );
+}

--- a/tests/cli_arg_validation.rs
+++ b/tests/cli_arg_validation.rs
@@ -608,3 +608,85 @@ fn presign_no_args_exits_2() {
     assert_eq!(code, Some(2));
     assert!(!stderr.is_empty());
 }
+
+// ---- AUTO_COMPLETE_SHELL env var ----
+//
+// The per-subcommand --auto-complete-shell arg is stripped of both its long
+// name and its env source by build_cli_command (only the top-level flag
+// remains). Upstream declares the arg with `env`, so without the env-source
+// stripping an exported AUTO_COMPLETE_SHELL would silently re-arm the hidden
+// arg and fire its clap side effects: sync source/target defaulted to
+// s3://ignored, required util targets no longer required.
+
+#[test]
+fn auto_complete_shell_env_does_not_lift_required_target() {
+    let (code, _stdout, stderr) = run(s7cmd_cmd()
+        .arg("get-bucket-versioning")
+        .env("AUTO_COMPLETE_SHELL", "bash"));
+    assert_eq!(
+        code,
+        Some(2),
+        "env var must not satisfy the required target; stderr={stderr}"
+    );
+    assert!(
+        stderr.to_lowercase().contains("required"),
+        "expected missing-required parse error; got: {stderr}"
+    );
+}
+
+#[test]
+fn auto_complete_shell_env_does_not_default_sync_paths() {
+    let (code, _stdout, stderr) = run(s7cmd_cmd().arg("sync").env("AUTO_COMPLETE_SHELL", "bash"));
+    assert_eq!(
+        code,
+        Some(2),
+        "sync must still require source/target with the env var set; stderr={stderr}"
+    );
+    assert!(
+        stderr.to_lowercase().contains("source"),
+        "expected missing source error; got: {stderr}"
+    );
+}
+
+#[test]
+fn auto_complete_shell_env_invalid_value_is_ignored() {
+    let (code, _stdout, stderr) = run(s7cmd_cmd()
+        .arg("get-bucket-versioning")
+        .env("AUTO_COMPLETE_SHELL", "not-a-shell"));
+    assert_eq!(code, Some(2));
+    assert!(
+        stderr.to_lowercase().contains("required") && !stderr.contains("invalid value"),
+        "env value must be ignored entirely, not parsed; got: {stderr}"
+    );
+}
+
+#[test]
+fn auto_complete_shell_env_does_not_default_clean_target() {
+    // s3rm-rs's target carries the same default_value_if — without the env
+    // stripping, `clean` with no target would proceed toward a real deletion
+    // pipeline against s3://ignored instead of failing validation.
+    let (code, _stdout, stderr) = run(s7cmd_cmd().arg("clean").env("AUTO_COMPLETE_SHELL", "bash"));
+    assert_eq!(
+        code,
+        Some(2),
+        "clean must still require a target with the env var set; stderr={stderr}"
+    );
+    assert!(
+        stderr.to_lowercase().contains("required"),
+        "expected missing target error; got: {stderr}"
+    );
+}
+
+#[test]
+fn auto_complete_shell_env_does_not_lift_cp_paths() {
+    let (code, _stdout, stderr) = run(s7cmd_cmd().arg("cp").env("AUTO_COMPLETE_SHELL", "bash"));
+    assert_eq!(
+        code,
+        Some(2),
+        "cp must still require source/target with the env var set; stderr={stderr}"
+    );
+    assert!(
+        stderr.to_lowercase().contains("required"),
+        "expected missing source/target error; got: {stderr}"
+    );
+}

--- a/tests/cli_arg_validation.rs
+++ b/tests/cli_arg_validation.rs
@@ -93,6 +93,40 @@ fn mv_missing_target_exits_2() {
     assert!(!stderr.is_empty());
 }
 
+// ---- mv self-move guard (ported from s3util-rs PR#25) ----
+//
+// mv is copy-then-delete, so moving an object onto itself would delete the
+// object the copy just wrote. The guard fires inside run_mv before any client
+// is built, so these run without AWS credentials or network — but as a
+// runtime rejection, not a clap error, the exit code is 1 (not 2).
+
+#[test]
+fn mv_self_move_identical_keys_exits_1() {
+    let (code, _stdout, stderr) =
+        run(s7cmd_cmd().args(["mv", "s3://b/dir/k.txt", "s3://b/dir/k.txt"]));
+    assert_eq!(code, Some(1), "mv onto itself must exit 1; stderr={stderr}");
+    assert!(
+        stderr.contains("onto itself"),
+        "expected the self-move rejection on stderr; got: {stderr}"
+    );
+}
+
+#[test]
+fn mv_self_move_directory_style_target_exits_1() {
+    // `mv s3://b/dir/k.txt s3://b/dir/` resolves the target to the source key
+    // by appending the basename — the same data-loss case spelled differently.
+    let (code, _stdout, stderr) = run(s7cmd_cmd().args(["mv", "s3://b/dir/k.txt", "s3://b/dir/"]));
+    assert_eq!(
+        code,
+        Some(1),
+        "directory-style self-move must exit 1; stderr={stderr}"
+    );
+    assert!(
+        stderr.contains("onto itself"),
+        "expected the self-move rejection on stderr; got: {stderr}"
+    );
+}
+
 // ---- cp --skip-existing validation (s3util-rs 1.2.0) ----
 
 #[test]

--- a/tests/cli_arg_validation.rs
+++ b/tests/cli_arg_validation.rs
@@ -690,3 +690,61 @@ fn auto_complete_shell_env_does_not_lift_cp_paths() {
         "expected missing source/target error; got: {stderr}"
     );
 }
+
+// ---- batch-run --parallel upper bound ----
+//
+// `--parallel` is capped at MAX_PARALLEL (1024). An oversized or overflowing
+// value must be rejected at clap parse time (exit 2), never reaching
+// `tokio::sync::Semaphore::new`, which panics (aborting with exit 101) once
+// the worker count exceeds `usize::MAX >> 3`. `s7cmd_cmd` closes stdin and the
+// parse error fires before any script read, so the `-` positional never blocks.
+
+#[test]
+fn batch_run_parallel_over_cap_exits_2() {
+    let (code, _stdout, stderr) = run(s7cmd_cmd().args(["batch-run", "--parallel", "100000", "-"]));
+    assert_eq!(
+        code,
+        Some(2),
+        "oversized --parallel must be a clean parse error; stderr={stderr}"
+    );
+    assert!(
+        stderr.to_lowercase().contains("no more than")
+            || stderr.to_lowercase().contains("parallel"),
+        "expected a --parallel range error; got: {stderr}"
+    );
+}
+
+#[test]
+fn batch_run_parallel_semaphore_panic_value_exits_2_not_101() {
+    // `usize::MAX >> 3` is tokio's Semaphore::MAX_PERMITS; one past it is the
+    // smallest value that used to panic `Semaphore::new` (exit 101).
+    let huge = (usize::MAX >> 3).wrapping_add(1).to_string();
+    let (code, _stdout, stderr) = run(s7cmd_cmd().args(["batch-run", "--parallel", &huge, "-"]));
+    assert_eq!(
+        code,
+        Some(2),
+        "must be a clean exit 2, not a panic; stderr={stderr}"
+    );
+}
+
+#[test]
+fn batch_run_parallel_overflow_value_exits_2() {
+    // Larger than usize::MAX → must fail to parse cleanly, not overflow/panic.
+    let (code, _stdout, _stderr) =
+        run(s7cmd_cmd().args(["batch-run", "--parallel", "99999999999999999999999999", "-"]));
+    assert_eq!(code, Some(2));
+}
+
+#[test]
+fn batch_run_parallel_at_cap_is_accepted() {
+    // MAX_PARALLEL (1024) itself must parse and run: with the closed stdin of
+    // `s7cmd_cmd` the run completes with a 0-command summary (exit 0), and
+    // `Semaphore::new(1024)` does not panic. Guards against an off-by-one that
+    // would reject the documented maximum.
+    let (code, _stdout, stderr) = run(s7cmd_cmd().args(["batch-run", "--parallel", "1024", "-"]));
+    assert_eq!(
+        code,
+        Some(0),
+        "MAX_PARALLEL must be accepted and run; stderr={stderr}"
+    );
+}

--- a/tests/cli_closed_stderr.rs
+++ b/tests/cli_closed_stderr.rs
@@ -1,0 +1,155 @@
+//! Every tracing family (sync, clean, ls, util) routes its output through a
+//! `PipeSafeWriter` that swallows `BrokenPipe` so a closed stderr (e.g.
+//! `s7cmd ... 2>&1 | head`) cannot panic the process. These tests pin that
+//! contract end to end: each family runs an offline-failing command twice —
+//! once normally and once with the parent's read end of the stderr pipe
+//! closed immediately after spawn — and must exit with the same code both
+//! times. A panic in the writer would surface as a different exit
+//! (101/abort) and fail the assertion.
+//!
+//! The commands point at a loopback endpoint with nothing listening, so
+//! the error output (the writes that must survive EPIPE) is produced
+//! without AWS access. Closing the pipe races the child's first write; the
+//! child needs tens of milliseconds of startup before it first logs, so
+//! the close wins in practice — and even when it doesn't, the assertion
+//! still holds (the run just degrades to the open-stderr case).
+
+mod common;
+
+use common::s7cmd_cmd_clean_env;
+use std::process::{Command, Stdio};
+
+const DEAD_ENDPOINT: &str = "http://127.0.0.1:9";
+
+fn with_fake_aws_env(cmd: &mut Command) -> &mut Command {
+    cmd.env("AWS_ACCESS_KEY_ID", "test")
+        .env("AWS_SECRET_ACCESS_KEY", "test")
+        .env("AWS_REGION", "us-east-1")
+}
+
+/// Spawn with stderr piped, close the read end immediately, and return the
+/// exit code. Stdout is discarded; stdin is closed.
+fn exit_code_with_closed_stderr(cmd: &mut Command) -> Option<i32> {
+    let mut child = cmd
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("failed to spawn s7cmd");
+    drop(child.stderr.take());
+    child.wait().expect("child.wait() failed").code()
+}
+
+fn assert_same_exit_with_closed_stderr(args: &[&str], expected: i32) {
+    let mut open = s7cmd_cmd_clean_env();
+    with_fake_aws_env(&mut open).args(args);
+    let open_code = open
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .expect("open-stderr run failed")
+        .code();
+    assert_eq!(
+        open_code,
+        Some(expected),
+        "baseline exit code changed for {args:?}"
+    );
+
+    let mut closed = s7cmd_cmd_clean_env();
+    with_fake_aws_env(&mut closed).args(args);
+    let closed_code = exit_code_with_closed_stderr(&mut closed);
+    assert_eq!(
+        closed_code,
+        Some(expected),
+        "closed stderr must not change the exit code (a panic would) for {args:?}"
+    );
+}
+
+/// sync is the odd one out: its tracing sink is stdout, so the closed
+/// stream must be stdout for the EPIPE-swallowing writer to be exercised.
+#[test]
+fn sync_with_closed_stdout_does_not_panic() {
+    let args = [
+        "sync",
+        "s3://src-bucket/",
+        "s3://dst-bucket/",
+        "--source-endpoint-url",
+        DEAD_ENDPOINT,
+        "--target-endpoint-url",
+        DEAD_ENDPOINT,
+        "--aws-max-attempts",
+        "1",
+    ];
+
+    let mut open = s7cmd_cmd_clean_env();
+    with_fake_aws_env(&mut open).args(args);
+    let open_code = open
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .expect("open-stdout run failed")
+        .code();
+    assert_eq!(open_code, Some(1), "baseline sync exit code changed");
+
+    let mut closed = s7cmd_cmd_clean_env();
+    with_fake_aws_env(&mut closed).args(args);
+    let mut child = closed
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("failed to spawn s7cmd");
+    drop(child.stdout.take());
+    let closed_code = child.wait().expect("child.wait() failed").code();
+    assert_eq!(
+        closed_code,
+        Some(1),
+        "closed stdout must not change sync's exit code (a panic would)"
+    );
+}
+
+#[test]
+fn clean_with_closed_stderr_does_not_panic() {
+    assert_same_exit_with_closed_stderr(
+        &[
+            "clean",
+            "--force",
+            "s3://some-bucket/prefix/",
+            "--target-endpoint-url",
+            DEAD_ENDPOINT,
+            "--aws-max-attempts",
+            "1",
+        ],
+        1,
+    );
+}
+
+#[test]
+fn ls_with_closed_stderr_does_not_panic() {
+    assert_same_exit_with_closed_stderr(
+        &[
+            "ls",
+            "s3://some-bucket",
+            "--target-endpoint-url",
+            DEAD_ENDPOINT,
+            "--aws-max-attempts",
+            "1",
+        ],
+        1,
+    );
+}
+
+#[test]
+fn util_command_with_closed_stderr_does_not_panic() {
+    assert_same_exit_with_closed_stderr(
+        &[
+            "get-bucket-versioning",
+            "s3://some-bucket",
+            "--target-endpoint-url",
+            DEAD_ENDPOINT,
+            "--aws-max-attempts",
+            "1",
+        ],
+        1,
+    );
+}

--- a/tests/cli_error_paths.rs
+++ b/tests/cli_error_paths.rs
@@ -1,0 +1,105 @@
+//! Process-level tests for runtime error paths that are reachable without
+//! AWS: every command below points at a loopback endpoint with nothing
+//! listening (connection refused is immediate), with fake credentials in
+//! env so client construction succeeds and failure happens at the request
+//! layer. Each test pins the family's error exit code and the message its
+//! runner logs on the failure path.
+
+mod common;
+
+use common::{run, s7cmd_cmd_clean_env};
+use std::process::Command;
+
+/// Refused loopback endpoint; nothing ever listens on port 9 (discard).
+const DEAD_ENDPOINT: &str = "http://127.0.0.1:9";
+
+fn with_fake_aws_env(cmd: &mut Command) -> &mut Command {
+    cmd.env("AWS_ACCESS_KEY_ID", "test")
+        .env("AWS_SECRET_ACCESS_KEY", "test")
+        .env("AWS_REGION", "us-east-1")
+}
+
+/// A sync whose listing fails must take the `has_error` path: log
+/// "s7cmd sync failed." (sync_bin/cli — sync's tracing sink is stdout),
+/// return Err, and exit 1 via the dispatch sync arm's error branch.
+#[test]
+fn sync_pipeline_failure_logs_and_exits_1() {
+    let mut cmd = s7cmd_cmd_clean_env();
+    with_fake_aws_env(&mut cmd).args([
+        "sync",
+        "s3://src-bucket/",
+        "s3://dst-bucket/",
+        "--source-endpoint-url",
+        DEAD_ENDPOINT,
+        "--target-endpoint-url",
+        DEAD_ENDPOINT,
+        "--aws-max-attempts",
+        "1",
+    ]);
+    let (code, stdout, stderr) = run(&mut cmd);
+    assert_eq!(
+        code,
+        Some(1),
+        "failed sync must exit 1; stdout={stdout} stderr={stderr}"
+    );
+    assert!(
+        stdout.contains("s7cmd sync failed."),
+        "expected the sync failure log on stdout (sync's tracing sink); \
+         stdout={stdout} stderr={stderr}"
+    );
+}
+
+/// A clean whose object listing fails must take the `has_error` path:
+/// log "s7cmd clean failed." (clean_bin) and exit 1.
+#[test]
+fn clean_listing_failure_logs_and_exits_1() {
+    let mut cmd = s7cmd_cmd_clean_env();
+    with_fake_aws_env(&mut cmd).args([
+        "clean",
+        "--force",
+        "s3://some-bucket/prefix/",
+        "--target-endpoint-url",
+        DEAD_ENDPOINT,
+        "--aws-max-attempts",
+        "1",
+    ]);
+    let (code, _stdout, stderr) = run(&mut cmd);
+    assert_eq!(code, Some(1), "failed clean must exit 1; stderr={stderr}");
+    assert!(
+        stderr.contains("s7cmd clean failed."),
+        "expected the clean failure log; got: {stderr}"
+    );
+}
+
+/// `cp --dry-run` with annotation sync enabled builds a source client
+/// (including the `--source-request-payer` requester option) and lists
+/// object annotations even in dry-run; with a dead endpoint the listing
+/// fails and cp exits 1 with the annotation error surfaced.
+#[test]
+fn cp_dry_run_annotation_sync_with_request_payer_fails_cleanly() {
+    let mut cmd = s7cmd_cmd_clean_env();
+    with_fake_aws_env(&mut cmd).args([
+        "cp",
+        "--dry-run",
+        "--enable-sync-object-annotations",
+        "--source-request-payer",
+        "s3://src-bucket/key",
+        "s3://dst-bucket/key",
+        "--source-endpoint-url",
+        DEAD_ENDPOINT,
+        "--target-endpoint-url",
+        DEAD_ENDPOINT,
+        "--aws-max-attempts",
+        "1",
+    ]);
+    let (code, _stdout, stderr) = run(&mut cmd);
+    assert_eq!(
+        code,
+        Some(1),
+        "annotation listing failure must exit 1; stderr={stderr}"
+    );
+    assert!(
+        stderr.contains("list_object_annotations"),
+        "expected the annotation-listing error; got: {stderr}"
+    );
+}

--- a/tests/cli_help.rs
+++ b/tests/cli_help.rs
@@ -607,3 +607,131 @@ fn version_long_flag_prints_pkg_version() {
         .success()
         .stdout(predicate::str::contains(expected));
 }
+
+// ---------------------------------------------------------------------------
+// Security: credential env values must not leak into --help output.
+//
+// clap renders the current value of an env-backed arg into help text unless
+// the arg is marked hide_env_values. Upstream adds that marker at the derive
+// level (s3sync PR#246, s3rm-rs PR#94, s3ls-rs PR#29, s3util-rs PR#25); until
+// those land in released crates, s7cmd enforces it in cli::build_cli_command.
+// These tests drive the real binary with secrets in the process environment —
+// one subcommand per upstream parser — and assert the values never appear
+// while the env var *names* still do.
+// ---------------------------------------------------------------------------
+
+/// Run `s7cmd <sub> --help` with credential env vars set; assert every
+/// (name, value) pair shows the name but never the value. A non-secret
+/// control var proves clap really does render env values at help time —
+/// without it, a clap behavior change could green these tests vacuously.
+fn assert_help_hides_credential_values(sub: &str, vars: &[(&str, &str)]) {
+    let mut cmd = Command::cargo_bin("s7cmd").unwrap();
+    cmd.args([sub, "--help"]);
+    for (name, value) in vars {
+        cmd.env(name, value);
+    }
+    // Control: TARGET_REGION is env-backed on every subcommand under test
+    // and is not a secret, so its value must render into help output.
+    cmd.env("TARGET_REGION", "us-west-2");
+
+    let assert = cmd.assert().success();
+    let stdout = String::from_utf8_lossy(&assert.get_output().stdout).to_string();
+
+    assert!(
+        stdout.contains("us-west-2"),
+        "{sub}: expected the non-secret TARGET_REGION value in help output \
+         (control that env values render at all)"
+    );
+    for (name, value) in vars {
+        assert!(
+            stdout.contains(name),
+            "{sub}: env var name {name} should still appear in help"
+        );
+        assert!(
+            !stdout.contains(value),
+            "{sub}: credential value for {name} leaked into --help output"
+        );
+    }
+}
+
+#[test]
+fn sync_help_hides_credential_env_values() {
+    assert_help_hides_credential_values(
+        "sync",
+        &[
+            ("SOURCE_ACCESS_KEY", "AKIA_sync_should_not_appear"),
+            ("SOURCE_SECRET_ACCESS_KEY", "SECRET_sync_should_not_appear"),
+            ("SOURCE_SESSION_TOKEN", "TOKEN_sync_should_not_appear"),
+            ("TARGET_ACCESS_KEY", "AKIA_sync_tgt_should_not_appear"),
+            (
+                "TARGET_SECRET_ACCESS_KEY",
+                "SECRET_sync_tgt_should_not_appear",
+            ),
+            ("TARGET_SESSION_TOKEN", "TOKEN_sync_tgt_should_not_appear"),
+            ("SOURCE_SSE_C_KEY", "SSECKEY_sync_should_not_appear"),
+            ("SOURCE_SSE_C_KEY_MD5", "SSECMD5_sync_should_not_appear"),
+            ("TARGET_SSE_C_KEY", "SSECKEY_sync_tgt_should_not_appear"),
+            ("TARGET_SSE_C_KEY_MD5", "SSECMD5_sync_tgt_should_not_appear"),
+        ],
+    );
+}
+
+#[test]
+fn clean_help_hides_credential_env_values() {
+    assert_help_hides_credential_values(
+        "clean",
+        &[
+            ("TARGET_ACCESS_KEY", "AKIA_clean_should_not_appear"),
+            ("TARGET_SECRET_ACCESS_KEY", "SECRET_clean_should_not_appear"),
+            ("TARGET_SESSION_TOKEN", "TOKEN_clean_should_not_appear"),
+        ],
+    );
+}
+
+#[test]
+fn ls_help_hides_credential_env_values() {
+    assert_help_hides_credential_values(
+        "ls",
+        &[
+            ("TARGET_ACCESS_KEY", "AKIA_ls_should_not_appear"),
+            ("TARGET_SECRET_ACCESS_KEY", "SECRET_ls_should_not_appear"),
+            ("TARGET_SESSION_TOKEN", "TOKEN_ls_should_not_appear"),
+        ],
+    );
+}
+
+#[test]
+fn cp_help_hides_credential_env_values() {
+    assert_help_hides_credential_values(
+        "cp",
+        &[
+            ("SOURCE_ACCESS_KEY", "AKIA_cp_should_not_appear"),
+            ("SOURCE_SECRET_ACCESS_KEY", "SECRET_cp_should_not_appear"),
+            ("SOURCE_SESSION_TOKEN", "TOKEN_cp_should_not_appear"),
+            ("TARGET_ACCESS_KEY", "AKIA_cp_tgt_should_not_appear"),
+            (
+                "TARGET_SECRET_ACCESS_KEY",
+                "SECRET_cp_tgt_should_not_appear",
+            ),
+            ("TARGET_SESSION_TOKEN", "TOKEN_cp_tgt_should_not_appear"),
+            ("SOURCE_SSE_C_KEY", "SSECKEY_cp_should_not_appear"),
+            ("SOURCE_SSE_C_KEY_MD5", "SSECMD5_cp_should_not_appear"),
+            ("TARGET_SSE_C_KEY", "SSECKEY_cp_tgt_should_not_appear"),
+            ("TARGET_SSE_C_KEY_MD5", "SSECMD5_cp_tgt_should_not_appear"),
+        ],
+    );
+}
+
+#[test]
+fn head_object_help_hides_credential_env_values() {
+    assert_help_hides_credential_values(
+        "head-object",
+        &[
+            ("TARGET_ACCESS_KEY", "AKIA_ho_should_not_appear"),
+            ("TARGET_SECRET_ACCESS_KEY", "SECRET_ho_should_not_appear"),
+            ("TARGET_SESSION_TOKEN", "TOKEN_ho_should_not_appear"),
+            ("SOURCE_SSE_C_KEY", "SSECKEY_ho_should_not_appear"),
+            ("SOURCE_SSE_C_KEY_MD5", "SSECMD5_ho_should_not_appear"),
+        ],
+    );
+}

--- a/tests/cli_put_bucket_lifecycle_configuration.rs
+++ b/tests/cli_put_bucket_lifecycle_configuration.rs
@@ -130,6 +130,39 @@ fn malformed_json_exits_1() {
     );
 }
 
+/// A top-level `TransitionDefaultMinimumObjectSize` — as emitted by
+/// `get-bucket-lifecycle-configuration` — must be rejected with guidance, not
+/// silently dropped (dropping it resets the bucket to S3's default on a
+/// get-edit-put roundtrip). Adapted from s3util-rs PR#25; the parse rejection
+/// fires before any AWS call, so this runs without credentials or network.
+#[test]
+fn transition_default_minimum_object_size_in_json_exits_1_with_guidance() {
+    let tmp = tempfile::NamedTempFile::new().unwrap();
+    std::fs::write(
+        tmp.path(),
+        br#"{"Rules": [{"ID": "r1", "Status": "Enabled",
+            "Expiration": {"Days": 30}, "Filter": {"Prefix": ""}}],
+            "TransitionDefaultMinimumObjectSize": "all_storage_classes_128K"}"#,
+    )
+    .unwrap();
+    let (ok, _stdout, stderr, code) = run(s7cmd().args([
+        "put-bucket-lifecycle-configuration",
+        "s3://example-bucket",
+        tmp.path().to_str().unwrap(),
+    ]));
+    assert!(!ok);
+    assert_eq!(
+        code,
+        Some(1),
+        "TransitionDefaultMinimumObjectSize in the document must exit 1; got {code:?}; stderr: {stderr}"
+    );
+    assert!(
+        stderr.contains("TransitionDefaultMinimumObjectSize")
+            && stderr.contains("request parameter"),
+        "expected guidance naming the field and calling it a request parameter; got: {stderr}"
+    );
+}
+
 #[test]
 fn target_no_sign_request_conflicts_with_target_profile() {
     let tmp = tempfile::NamedTempFile::new().unwrap();

--- a/tests/cli_routing.rs
+++ b/tests/cli_routing.rs
@@ -591,3 +591,42 @@ fn parses_batch_run_with_parallel_streaming_continue() {
     assert!(args.no_summary);
     assert_eq!(args.script, "-");
 }
+
+/// The per-subcommand --auto-complete-shell inherited from the upstream args
+/// structs must be fully disarmed on every subcommand: hidden from help, no
+/// long name (clap_complete ignores hide(true)), and no env source — an
+/// exported AUTO_COMPLETE_SHELL would otherwise re-arm the hidden arg and
+/// fire its clap side effects (default_value_if on sync/clean paths,
+/// required_unless_present on util targets). Only the top-level
+/// --auto-complete-shell remains user-visible.
+#[test]
+fn per_subcommand_auto_complete_shell_is_fully_disarmed() {
+    let cmd = cli::cli_command();
+    let mut seen = 0;
+    for sub in cmd.get_subcommands() {
+        for arg in sub.get_arguments() {
+            if arg.get_id().as_str() == "auto_complete_shell" {
+                seen += 1;
+                assert!(
+                    arg.is_hide_set(),
+                    "{}: --auto-complete-shell not hidden",
+                    sub.get_name()
+                );
+                assert!(
+                    arg.get_long().is_none(),
+                    "{}: --auto-complete-shell long name still set",
+                    sub.get_name()
+                );
+                assert!(
+                    arg.get_env().is_none(),
+                    "{}: --auto-complete-shell env source still set",
+                    sub.get_name()
+                );
+            }
+        }
+    }
+    assert!(
+        seen > 30,
+        "expected the inherited flag on most subcommands, saw only {seen}"
+    );
+}

--- a/tests/cli_sigint.rs
+++ b/tests/cli_sigint.rs
@@ -1,0 +1,144 @@
+//! SIGINT handling for `batch-run`, which needs no AWS access — so unlike
+//! the transfer commands (covered in `tests/e2e_ctrl_c.rs`) these run under
+//! a plain `cargo test`.
+//!
+//! Unix-only: SIGINT delivery via the `nix` crate.
+
+#![cfg(unix)]
+
+use nix::sys::signal::{Signal, kill};
+use nix::unistd::Pid;
+use std::io::Write;
+use std::process::{Command, Stdio};
+use std::time::{Duration, Instant};
+
+const STARTUP_DELAY: Duration = Duration::from_millis(1500);
+const WAIT_TIMEOUT: Duration = Duration::from_secs(30);
+
+fn s7cmd() -> Command {
+    Command::new(env!("CARGO_BIN_EXE_s7cmd"))
+}
+
+/// Poll for child exit up to `WAIT_TIMEOUT`. Returns `None` if it never
+/// exits, so callers can assert "did not hang" without blocking a CI run
+/// forever.
+fn wait_bounded(child: &mut std::process::Child) -> Option<std::process::ExitStatus> {
+    let deadline = Instant::now() + WAIT_TIMEOUT;
+    while Instant::now() < deadline {
+        match child.try_wait().expect("try_wait failed") {
+            Some(status) => return Some(status),
+            None => std::thread::sleep(Duration::from_millis(50)),
+        }
+    }
+    None
+}
+
+/// Non-streaming `batch-run -` spends phase 1 in a blocking read of stdin
+/// under the *default* SIGINT disposition (the handler is installed only
+/// after the script has been read), so Ctrl-C there terminates the process
+/// by signal — exactly the "I haven't started anything yet" intuition the
+/// phase-1 comment describes. `code()` is `None` for a signal death;
+/// the signal number is 2 (SIGINT).
+#[test]
+fn batch_run_sigint_while_reading_stdin_dies_by_signal() {
+    use std::os::unix::process::ExitStatusExt;
+
+    let mut child = s7cmd()
+        .args(["batch-run", "-"])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("failed to spawn s7cmd");
+
+    std::thread::sleep(STARTUP_DELAY);
+    let _ = kill(Pid::from_raw(child.id() as i32), Signal::SIGINT);
+
+    let status = wait_bounded(&mut child).unwrap_or_else(|| {
+        let _ = child.kill();
+        panic!("batch-run did not exit within {WAIT_TIMEOUT:?} of SIGINT during phase-1 read");
+    });
+    assert_eq!(
+        status.signal(),
+        Some(2),
+        "phase-1 SIGINT must terminate by signal; got {status:?}"
+    );
+}
+
+/// Streaming `batch-run --streaming -` sitting idle on stdin: SIGINT sets
+/// the shared interrupt flag and trips the reader's `ctrl_c` select arm, so
+/// once stdin also reaches EOF the run finishes cleanly with exit 0 (no
+/// line ever executed, so nothing is "failed" or "skipped").
+///
+/// The stdin close after the signal is load-bearing, not incidental:
+/// streaming mode reads via `tokio::io::stdin()`, which tokio implements as
+/// an uncancellable blocking read on a helper thread. Tokio documents that
+/// this "can make shutdown of the runtime hang until the user presses
+/// enter" — so a `--streaming -` run whose stdin pipe never closes does NOT
+/// exit on SIGINT alone. This test therefore pins the reachable contract
+/// (signal + EOF → prompt, clean exit); the pipe-stays-open hang is a
+/// separate defect in the product, not something to assert as correct here.
+#[test]
+fn batch_run_streaming_sigint_then_eof_exits_0() {
+    let mut child = s7cmd()
+        .args(["batch-run", "--streaming", "-"])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("failed to spawn s7cmd");
+
+    std::thread::sleep(STARTUP_DELAY);
+    let _ = kill(Pid::from_raw(child.id() as i32), Signal::SIGINT);
+
+    // Let the signal be observed, then release the blocking stdin read.
+    std::thread::sleep(Duration::from_millis(300));
+    drop(child.stdin.take());
+
+    let status = wait_bounded(&mut child).unwrap_or_else(|| {
+        let _ = child.kill();
+        panic!("streaming batch-run did not exit within {WAIT_TIMEOUT:?} of SIGINT + EOF");
+    });
+    assert_eq!(
+        status.code(),
+        Some(0),
+        "interrupted idle streaming batch must exit 0; got {status:?}"
+    );
+}
+
+/// The same streaming path with real work queued: lines are written before
+/// the signal, stdin is closed after it, and the run still exits cleanly.
+/// Every line is a `--dry-run` so no S3 endpoint is contacted.
+#[test]
+fn batch_run_streaming_sigint_with_queued_lines_exits_cleanly() {
+    let mut child = s7cmd()
+        .args(["batch-run", "--streaming", "--disable-color-tracing", "-"])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("failed to spawn s7cmd");
+
+    {
+        let stdin = child.stdin.as_mut().expect("stdin piped");
+        for i in 0..3 {
+            writeln!(stdin, "create-bucket --dry-run s3://sigint-stream-{i}").expect("write line");
+        }
+        stdin.flush().expect("flush");
+    }
+
+    std::thread::sleep(STARTUP_DELAY);
+    let _ = kill(Pid::from_raw(child.id() as i32), Signal::SIGINT);
+    std::thread::sleep(Duration::from_millis(300));
+    drop(child.stdin.take());
+
+    let status = wait_bounded(&mut child).unwrap_or_else(|| {
+        let _ = child.kill();
+        panic!("streaming batch-run did not exit within {WAIT_TIMEOUT:?} of SIGINT + EOF");
+    });
+    assert_eq!(
+        status.code(),
+        Some(0),
+        "dry-run lines all succeed, so an interrupt after them exits 0; got {status:?}"
+    );
+}

--- a/tests/e2e_ctrl_c.rs
+++ b/tests/e2e_ctrl_c.rs
@@ -1,8 +1,8 @@
 //! Process-level e2e tests for graceful Ctrl+C handling.
 //!
 //! Each test spawns the binary directly (NOT via cargo run — cargo
-//! intercepts SIGINT), gives it ~1.5s to enter its work loop, sends SIGINT,
-//! and asserts the child exits with code 130 within a 30s timeout.
+//! intercepts SIGINT), waits for it to enter its work loop, sends SIGINT,
+//! and asserts the child exits with the expected code within a 30s timeout.
 //!
 //! Unix-only: SIGINT delivery via the `nix` crate.
 
@@ -19,39 +19,86 @@ use nix::unistd::Pid;
 use std::process::Stdio;
 use std::time::Duration;
 
-const STARTUP_DELAY_MS: u64 = 1500;
+/// How long to let the child run before delivering SIGINT, per attempt.
+///
+/// A single fixed delay is machine-dependent and was the source of flaky
+/// `None` results: the commands install their Ctrl-C handler only after
+/// credential/profile loading and client construction, and an s3→s3 command
+/// (mv) builds *two* clients before it gets there. Signal too early and the
+/// default disposition kills the process outright.
+///
+/// `run_with_sigint` escalates through these delays, so a slower machine or
+/// higher-latency region self-corrects instead of failing. The largest delay
+/// must still be comfortably inside every test's throttled work window (the
+/// shortest is ~15s: a 30 MiB transfer at `--rate-limit-bandwidth 2MiB`).
+const STARTUP_DELAYS_MS: [u64; 3] = [2000, 5000, 9000];
 const WAIT_TIMEOUT_SECS: u64 = 30;
 
-/// Spawn `cmd`, sleep `STARTUP_DELAY_MS`, deliver SIGINT, wait for exit
-/// (capped at `WAIT_TIMEOUT_SECS`), and return the exit code. Stdout and
-/// stderr of the child are discarded — these tests assert on exit code,
-/// not output.
+/// Signal-timing tests must not run concurrently. `run_with_sigint` waits a
+/// bounded time for the child to install its Ctrl-C handler, and a machine
+/// busy seeding objects for another test can push a child past that window —
+/// SIGINT then lands under the *default* disposition and kills it outright
+/// (exit code `None`) instead of driving graceful cancellation. The retry in
+/// `run_with_sigint` recovers from that, but only after re-running the whole
+/// command; holding this lock for each test body keeps the machine
+/// uncontended so the first attempt usually suffices.
+static SIGINT_TEST_LOCK: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
+
+/// Spawn `cmd`, let it settle, deliver SIGINT, wait for exit (capped at
+/// `WAIT_TIMEOUT_SECS`), and return the exit code. Stdout and stderr of the
+/// child are discarded — these tests assert on exit code, not output.
+///
+/// Returns `None` only if the child was terminated *by* the signal rather
+/// than exiting on its own. That specifically means the Ctrl-C handler was
+/// not yet installed when the signal landed, so the attempt is retried with
+/// a longer startup delay. Retrying is safe precisely because a child that
+/// died this way was still starting up: it had not begun the throttled
+/// transfer/listing/deletion, so the seeded workload is untouched.
 async fn run_with_sigint(cmd: &mut std::process::Command) -> Option<i32> {
-    let mut child = cmd
-        .stdin(Stdio::null())
-        .stdout(Stdio::null())
-        .stderr(Stdio::null())
-        .spawn()
-        .expect("failed to spawn s7cmd");
+    for (attempt, delay_ms) in STARTUP_DELAYS_MS.iter().enumerate() {
+        let mut child = cmd
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+            .expect("failed to spawn s7cmd");
 
-    tokio::time::sleep(Duration::from_millis(STARTUP_DELAY_MS)).await;
-    let pid = Pid::from_raw(child.id() as i32);
-    let _ = kill(pid, Signal::SIGINT);
+        tokio::time::sleep(Duration::from_millis(*delay_ms)).await;
+        let pid = Pid::from_raw(child.id() as i32);
+        let _ = kill(pid, Signal::SIGINT);
 
-    // Bounded wait so a hang fails fast instead of stalling CI.
-    let wait_handle = tokio::task::spawn_blocking(move || child.wait());
-    match tokio::time::timeout(Duration::from_secs(WAIT_TIMEOUT_SECS), wait_handle).await {
-        Ok(Ok(Ok(status))) => status.code(),
-        Ok(Ok(Err(e))) => panic!("child.wait() failed: {e}"),
-        Ok(Err(e)) => panic!("spawn_blocking join failed: {e}"),
-        Err(_) => panic!("child did not exit within {WAIT_TIMEOUT_SECS}s after SIGINT"),
+        // Bounded wait so a hang fails fast instead of stalling CI.
+        let wait_handle = tokio::task::spawn_blocking(move || child.wait());
+        let status =
+            match tokio::time::timeout(Duration::from_secs(WAIT_TIMEOUT_SECS), wait_handle).await {
+                Ok(Ok(Ok(status))) => status,
+                Ok(Ok(Err(e))) => panic!("child.wait() failed: {e}"),
+                Ok(Err(e)) => panic!("spawn_blocking join failed: {e}"),
+                Err(_) => panic!("child did not exit within {WAIT_TIMEOUT_SECS}s after SIGINT"),
+            };
+
+        match status.code() {
+            Some(code) => return Some(code),
+            None => {
+                eprintln!(
+                    "SIGINT at {delay_ms}ms killed the child before its handler was installed \
+                     (attempt {}/{}); retrying with a longer delay",
+                    attempt + 1,
+                    STARTUP_DELAYS_MS.len(),
+                );
+            }
+        }
     }
+    // Every attempt died by signal — report it as such so the caller's
+    // assertion fails with the same `None` it would have seen before.
+    None
 }
 
 // ---- sync ----
 
 #[tokio::test]
 async fn cancel_sync_sigint_does_not_hang() {
+    let _serial = SIGINT_TEST_LOCK.lock().await;
     // sync's exit-on-SIGINT is non-deterministic: src/sync_bin/cli/mod.rs has
     // no explicit "cancelled → exit 130" path. Depending on what the pipeline
     // had done by the time SIGINT lands, the process can exit 0 (clean
@@ -93,9 +140,10 @@ async fn cancel_sync_sigint_does_not_hang() {
 
 #[tokio::test]
 async fn cancel_ls_sigint_does_not_hang() {
+    let _serial = SIGINT_TEST_LOCK.lock().await;
     // S3 paginates ListObjectsV2 at 1000 objects; --rate-limit-api throttles
     // BETWEEN pages, not within a page, so 200 objects in a single page
-    // would return before the 1500ms SIGINT delivery on a fast network.
+    // would return before SIGINT is delivered on a fast network.
     // Seeding 1000+ objects to force multi-page listing is wasteful for a
     // dispatch-only test, so we fall back to the spec-authorized soft
     // assertion: confirm the process exits (i.e. doesn't hang) and that
@@ -103,6 +151,10 @@ async fn cancel_ls_sigint_does_not_hang() {
     // very fast listing, the process may complete normally before SIGINT
     // lands. The richer "must exit 130" assertion is covered by sync, cp,
     // mv, and clean (which all have per-byte/per-object throttles).
+    //
+    // `--rate-limit-api` must be >= 10 (its clap range is 10..=u32::MAX);
+    // a lower value makes the run die at exit 2 before any S3 call, which
+    // this test's exit-code-agnostic assertion would silently accept.
     let helper = TestHelper::new().await;
     let bucket = generate_bucket_name();
     helper.create_bucket(&bucket, REGION).await;
@@ -122,13 +174,19 @@ async fn cancel_ls_sigint_does_not_hang() {
         REGION,
         "--recursive",
         "--rate-limit-api",
-        "1",
+        "10",
         &target,
     ]);
 
     // run_with_sigint already enforces a 30s timeout — passing it means the
-    // process exited (not hung). We don't assert on the exit code.
-    let _code = run_with_sigint(&mut cmd).await;
+    // process exited (not hung). We don't assert on the exit code, but it
+    // must not be the clap-error 2 (that would mean nothing was listed).
+    let code = run_with_sigint(&mut cmd).await;
+    assert_ne!(
+        code,
+        Some(2),
+        "invocation must be valid enough to reach the listing"
+    );
 
     helper.delete_bucket_with_cascade(&bucket).await;
 }
@@ -137,6 +195,7 @@ async fn cancel_ls_sigint_does_not_hang() {
 
 #[tokio::test]
 async fn cancel_clean_sigint_does_not_hang() {
+    let _serial = SIGINT_TEST_LOCK.lock().await;
     // clean's bulk-delete is too fast to reliably catch with SIGINT at scale
     // suitable for a dispatch test. --rate-limit-objects has hard floor 10
     // and must be >= --batch-size (default 200), so the practical minimum
@@ -181,6 +240,7 @@ async fn cancel_clean_sigint_does_not_hang() {
 
 #[tokio::test]
 async fn cancel_cp_sigint_exits_130() {
+    let _serial = SIGINT_TEST_LOCK.lock().await;
     let helper = TestHelper::new().await;
     let bucket = generate_bucket_name();
     helper.create_bucket(&bucket, REGION).await;
@@ -214,6 +274,7 @@ async fn cancel_cp_sigint_exits_130() {
 
 #[tokio::test]
 async fn cancel_mv_sigint_exits_130() {
+    let _serial = SIGINT_TEST_LOCK.lock().await;
     let helper = TestHelper::new().await;
     let src_bucket = generate_bucket_name();
     let dst_bucket = generate_bucket_name();
@@ -250,3 +311,108 @@ async fn cancel_mv_sigint_exits_130() {
     helper.delete_bucket_with_cascade(&src_bucket).await;
     helper.delete_bucket_with_cascade(&dst_bucket).await;
 }
+
+// ---- cancellation-path coverage ----
+//
+// The two tests below differ from the "does_not_hang" family above: they
+// shape the workload so SIGINT reliably lands while the operation is still
+// in flight, driving the explicit cancellation returns (ls_bin's
+// "listing cancelled" → 0 and clean_bin's "deletion cancelled" → 0).
+//
+// NOTE on flag values: `--rate-limit-api` has a hard floor of 10
+// (`10..=u32::MAX`). A smaller value is a clap error (exit 2) that kills
+// the run before any S3 call — which a bare "process exited" assertion
+// would silently accept. Keep throttles at or above their documented
+// floors and prefer asserting a specific exit code.
+
+/// ls with `--max-keys 1` over 150 objects forces 150 paginated
+/// ListObjectsV2 calls; `--rate-limit-api 10` (the floor) spaces them
+/// ~10/sec for roughly 15s of listing — comfortably longer than the largest
+/// startup delay in `STARTUP_DELAYS_MS`, so SIGINT always lands mid-listing
+/// and the cancellation branch (exit 0) is taken.
+#[tokio::test]
+async fn cancel_ls_sigint_mid_paginated_listing_exits_0() {
+    let _serial = SIGINT_TEST_LOCK.lock().await;
+    let helper = TestHelper::new().await;
+    let bucket = generate_bucket_name();
+    helper.create_bucket(&bucket, REGION).await;
+    for i in 0..150 {
+        helper
+            .put_object(&bucket, &format!("k{i:04}"), b"x".to_vec())
+            .await;
+    }
+
+    let target = format!("s3://{bucket}/");
+    let mut cmd = s7cmd_cmd();
+    cmd.args([
+        "ls",
+        "--target-profile",
+        "s7cmd-e2e-test",
+        "--target-region",
+        REGION,
+        "--recursive",
+        "--max-keys",
+        "1",
+        "--rate-limit-api",
+        "10",
+        &target,
+    ]);
+
+    let code = run_with_sigint(&mut cmd).await;
+    assert_eq!(
+        code,
+        Some(0),
+        "cancelled listing must exit 0 (ls cancellation path)"
+    );
+
+    helper.delete_bucket_with_cascade(&bucket).await;
+}
+
+/// clean over 200 objects with `--batch-size 10 --rate-limit-objects 10`
+/// keeps the deletion pipeline busy for ~20s of theoretical work, so SIGINT
+/// lands mid-run at any delay in `STARTUP_DELAYS_MS` and drives the post-run
+/// "deletion cancelled" branch (exit 0). If the leaky-bucket burst finishes
+/// the bucket first, the run still exits 0 — the assertion is stable either
+/// way; only the covered branch differs.
+#[tokio::test]
+async fn cancel_clean_sigint_mid_deletion_exits_0() {
+    let _serial = SIGINT_TEST_LOCK.lock().await;
+    let helper = TestHelper::new().await;
+    let bucket = generate_bucket_name();
+    helper.create_bucket(&bucket, REGION).await;
+    for i in 0..200 {
+        helper
+            .put_object(&bucket, &format!("k{i:04}"), b"x".to_vec())
+            .await;
+    }
+
+    let target = format!("s3://{bucket}/");
+    let mut cmd = s7cmd_cmd();
+    cmd.args([
+        "clean",
+        "--target-profile",
+        "s7cmd-e2e-test",
+        "--target-region",
+        REGION,
+        "--force",
+        "--batch-size",
+        "10",
+        "--rate-limit-objects",
+        "10",
+        &target,
+    ]);
+
+    let code = run_with_sigint(&mut cmd).await;
+    assert_eq!(
+        code,
+        Some(0),
+        "cancelled deletion must exit 0 (clean cancellation path)"
+    );
+
+    helper.delete_bucket_with_cascade(&bucket).await;
+}
+
+// batch-run's SIGINT behavior needs no AWS, so its coverage lives in
+// tests/cli_sigint.rs (runs under a plain `cargo test` on Unix) rather
+// than here. See that file for the documented caveat about
+// `--streaming -` with a stdin pipe that never closes.


### PR DESCRIPTION
Ports the fixes from s3sync #246/#245, s3rm-rs #94, s3ls-rs #29, and s3util-rs #25 that live in code s7cmd owns (the CLI builder and the vendored bin runners). The upstream library-level fixes are not yet in any released crate; they reach s7cmd via pin bumps when upstream publishes (see the CHANGELOG "Pending upstream releases" note).

- cli: hide credential env-var values in --help on every subcommand (access keys, secret keys, session tokens, SSE-C key material). Enforced in build_cli_command until the released upstream crates carry their own hide_env_values fixes; idempotent once they do
- util_bin cp/mv: report a worker failure that cancelled the pipeline token as a failure (exit 1) with its error logged, instead of as a SIGINT cancellation (exit 130) with the message suppressed
- util_bin cp/mv: resolve a local target with a trailing '/' to <dir>/<basename> on Windows too (adapted to 1.7.1's fs_util::is_key_a_directory; upstream's has_trailing_separator lands in a later release)
- util_bin mv: reject moving an S3 object onto itself before the copy runs — copy-then-delete destroyed the object on unversioned buckets while still exiting 0
- util_bin put-bucket-lifecycle-configuration: reject a top-level TransitionDefaultMinimumObjectSize with guidance instead of silently dropping it and resetting the bucket to S3's default on a get-edit-put roundtrip (adapted: 1.7.1 lacks deny_unknown_fields)
- docs: add README "Security assumptions" section (mirroring the ones the upstream PRs added) and a detailed CHANGELOG entry
- tests: unit, wiring, and process-level coverage for all of the above, including --help credential-leak tests with a positive control

## Contributing

- Bug reports are welcome, but responses are not guaranteed.
- Since this project is considered functionally complete, I will not accept any feature requests.
- If you find this project useful, feel free to fork and modify it as you wish.

🔒 I consider this project “complete” and will maintain it only minimally going forward.
However, I intend to keep the AWS SDK for Rust and other dependencies up to date monthly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security**
  * Credential and encryption-key values are now hidden from command help output (environment variable names still visible).
  * `--help` output is hardened to avoid leaking sensitive values from inherited completion settings.
  * Expanded “Security assumptions” documentation and endpoint/bucket trust limitations.

* **Bug Fixes**
  * Improved copy/move cancellation classification, trailing-slash directory target resolution, and self-move prevention.
  * `put-bucket-*` state-flag validation is enforced earlier without prematurely ending batch runs.
  * Lifecycle and related JSON inputs now reject unsupported request parameters with guidance.

* **Documentation**
  * Updated changelog with current fixes and pending upstream items.

* **Tests**
  * Added/expanded CLI, cancellation, SIGINT, and closed-pipe robustness coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->