### PR TITLE
feat(deps): update to s3sync 1.60.0, s3util-rs 1.8.0, s3rm-rs 1.4.0, …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,96 +5,118 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [1.6.0] - 2026-07-20
 
-Ports the applicable fixes from s3sync [PR#246](https://github.com/nidor1998/s3sync/pull/246) /
-[PR#245](https://github.com/nidor1998/s3sync/pull/245), s3rm-rs
-[PR#94](https://github.com/nidor1998/s3rm-rs/pull/94), s3ls-rs
-[PR#29](https://github.com/nidor1998/s3ls-rs/pull/29), and s3util-rs
-[PR#25](https://github.com/nidor1998/s3util-rs/pull/25) into s7cmd's own code
-(the CLI builder and the vendored bin runners). It also includes two independent hardening fixes to s7cmd's own
-`batch-run` / CLI code found in a security review — inline-credential redaction in per-line logs, and a `--parallel`
-upper bound (see **Security** and **Fixed › batch-run** below).
+Monthly update.
 
-Those upstream PRs have since shipped: this release also updates the pinned libraries to their 2026-07-20 releases —
-s3sync `v1.60.0`, s3util-rs `v1.8.0`, s3rm-rs `v1.4.0`, s3ls-rs `v1.1.0` — bringing in the remaining library-side
-fixes and the new `--transition-default-minimum-object-size` option (see **Added** and **Changed** below), and
-reconciles the vendored runners with the released code (request-payer wiring, lifecycle-flag wiring, and the
-`fs_util::has_trailing_separator` helper).
+Security and bug-fix release. It rolls up a large batch of security and correctness fixes across s7cmd and its four
+underlying libraries: the pinned libraries are updated to their 2026-07-20 releases — s3sync `v1.60.0`, s3util-rs
+`v1.8.0`, s3rm-rs `v1.4.0`, s3ls-rs `v1.1.0` — and issues found in s7cmd's own CLI and `batch-run` code by a
+security review are fixed as well (see **Security** and **Fixed** below). `put-bucket-lifecycle-configuration`
+gains one new option (see **Added**).
+
+**Upgrade notes:**
+
+- **IAM policies may need updating.** `cp`, `mv`, and S3-to-stdout downloads now pin reads to the object version
+  observed at the start of the transfer, and S3 authorizes version-pinned reads against `s3:GetObjectVersion`
+  instead of `s3:GetObject`. On buckets that have (or ever had) versioning enabled, least-privilege policies that
+  grant only the unversioned actions will start failing with `AccessDenied` — see **Changed** below for the full
+  list of required actions. Unversioned buckets are unaffected.
+- **Building from source** now requires Rust `1.94.1` or later. Pre-built binaries are unaffected.
 
 ### Added
 
-#### s3util-rs
+#### put-bucket-lifecycle-configuration
 
-- `put-bucket-lifecycle-configuration` gains `--transition-default-minimum-object-size`
-  (`varies_by_storage_class` or `all_storage_classes_128K`), sent to S3 as the request parameter of the same name.
-  S3 accepts the value only as a request parameter — never inside the lifecycle configuration document — so this is
-  the only way to preserve a non-default setting across a get-edit-put roundtrip
-  (see **Fixed › put-bucket-lifecycle-configuration** below).
+- New `--transition-default-minimum-object-size` option (`varies_by_storage_class` or `all_storage_classes_128K`),
+  sent to S3 as the request parameter of the same name. S3 accepts the value only as a request parameter — never
+  inside the lifecycle configuration document — so this option is the only way to preserve a non-default setting
+  across a get-edit-put roundtrip (see **Fixed › put-bucket-lifecycle-configuration** below).
 
 ### Security
 
 - Credential-related command line options no longer display their values in `--help` output when set via environment
   variables, on every subcommand: access keys, secret access keys, session tokens (`*_ACCESS_KEY`,
-  `*_SECRET_ACCESS_KEY`, `*_SESSION_TOKEN`), and SSE-C key material (`*_SSE_C_KEY`, `*_SSE_C_KEY_MD5`). The
-  environment-variable names are still shown. The pinned releases of all four libraries (s3sync `v1.60.0`, s3rm-rs
-  `v1.4.0`, s3ls-rs `v1.1.0`, s3util-rs `v1.8.0`) now carry the same `hide_env_values` marking at the derive level;
-  s7cmd keeps enforcing it when it builds its clap command tree — an idempotent no-op today — as a guard against a
-  future upstream credential argument that misses the marking.
+  `*_SECRET_ACCESS_KEY`, `*_SESSION_TOKEN`), and SSE-C key material (`*_SSE_C_KEY`, `*_SSE_C_KEY_MD5`). Previously
+  the exported secret itself appeared in the help text — and from there in terminal scrollback or captured CI logs;
+  now only the environment-variable name is shown.
 - `batch-run` no longer echoes inline credential values from a script line into its logs. A per-line command may
-  legally carry a credential on the command line (`--target-secret-access-key`, `--source-secret-access-key`,
-  `--*-access-key`, `--*-session-token`, `--*-sse-c-key`, `--*-sse-c-key-md5`); batch-run logs each line's raw text as
-  the `raw` field on per-line events, and the `warning` / `failure` / `invalid` / `panicked` events are emitted at the
-  default verbosity (and, with `--json-tracing`, into machine-readable JSON). The value of every such credential flag —
-  the same set hidden from `--help` above — is now masked to `****` before the line is logged; a line carrying no
-  credential is logged unchanged.
+  legally carry a credential on the command line (`--*-access-key`, `--*-secret-access-key`, `--*-session-token`,
+  `--*-sse-c-key`, `--*-sse-c-key-md5`), and batch-run logs each line's raw text on its per-line events — the
+  `warning` / `failure` / `invalid` / `panicked` events at the default verbosity and, with `--json-tracing`, as
+  machine-readable JSON. The value of every such credential option — the same set hidden from `--help` above — is
+  now masked to `****` before the line is logged; a line carrying no credential is logged unchanged.
 
 ### Fixed
 
-#### cp / mv (ported from s3util-rs PR#25 into the vendored runner)
+#### All subcommands
+
+- An exported `AUTO_COMPLETE_SHELL` environment variable no longer alters how subcommands parse and run. The
+  underlying libraries attach a hidden per-subcommand `--auto-complete-shell` option that also reads this
+  environment variable, so exporting it (for example, for one of the standalone upstream tools) armed the hidden
+  option on every s7cmd subcommand. That silently rewrote argument handling — `sync` / `clean` source and target
+  paths defaulted to a placeholder bucket, and otherwise-required arguments on other subcommands stopped being
+  required — and the command then went on to execute instead of printing shell completions the way the standalone
+  tools do; destructive subcommands such as `rm` and `clean` could run where a completion listing was expected.
+  Subcommands now ignore the variable entirely; shell completions are generated by s7cmd's own top-level
+  `--auto-complete-shell` option, which is unchanged.
+
+#### cp / mv
 
 - A transfer-worker failure that cancels the internal pipeline (e.g. a failed chunk download or a stdout write error
   during parallel S3-to-stdout downloads) is now reported as a failure (exit code 1) with its error logged, instead of
   being misreported as a user cancellation (exit code 130) with the error message suppressed. A genuine SIGINT still
   exits 130.
 - A local target directory spelled with a trailing forward slash (e.g. `out/`) now resolves to `out/<basename>` on
-  Windows as well. Previously the `/` form was only recognized on Unix, so on Windows the storage layer treated the
-  literal key `out/` as a directory and silently wrote nothing (and `mv` would then delete the source).
+  Windows as well. Previously the `/` form was only recognized on Unix, so on Windows the literal path `out/` was
+  treated as a directory and nothing was written (and `mv` would then delete the source).
 - `mv` now rejects moving an S3 object onto itself (`mv s3://b/k s3://b/k`, including directory-style and bucket-only
   spellings that resolve to the source key). `mv` is copy-then-delete, so a self-move deleted the object it had just
   written on an unversioned bucket — and still exited 0. Moves between different endpoints with equal bucket/key names
   are still allowed, and an explicit `--source-version-id` (other than `null`) is still accepted as a
   version-promotion operation.
 
-#### put-bucket-lifecycle-configuration (from s3util-rs v1.8.0)
+#### put-bucket-lifecycle-configuration
 
 - A top-level `TransitionDefaultMinimumObjectSize` key in the input JSON — as produced by
   `get-bucket-lifecycle-configuration` — is now rejected with guidance instead of being silently dropped. S3 accepts
   the value only as a request parameter, never inside the configuration document, so silently dropping it reset a
   bucket configured with `varies_by_storage_class` back to S3's default of `all_storage_classes_128K` on a
-  get-edit-put roundtrip. With s3util-rs `v1.8.0` the vendored runner adopts the released implementation: the
-  library's input structs reject *every* unknown JSON field (`deny_unknown_fields`), and the runner maps the
-  `TransitionDefaultMinimumObjectSize` rejection to guidance pointing at the new
-  `--transition-default-minimum-object-size` flag (see **Added**), which sends the value the way S3 accepts it.
+  get-edit-put roundtrip. The error points to the new `--transition-default-minimum-object-size` option (see
+  **Added**), which sends the value the way S3 accepts it. More generally, every `put-*` JSON input now rejects
+  unknown fields (see **Changed**).
 
 #### batch-run
 
-- `batch-run --parallel` now rejects a value greater than 1024 at parse time (a clean exit 2) instead of accepting an
-  arbitrarily large worker count. A value above `usize::MAX >> 3` reached `tokio::sync::Semaphore::new` and panicked,
-  aborting the whole run with exit 101 before any line executed; the bound also stops an oversized-but-valid value from
-  spawning a runaway number of concurrent commands (file-descriptor / connection exhaustion). `--parallel 0` (use all
-  logical CPUs) is still accepted.
+- `--parallel` now rejects a value greater than 1024 at parse time (a clean exit 2) instead of accepting an
+  arbitrarily large worker count, and the `--help` text documents the limit. An extremely large value previously
+  panicked and aborted the whole run with exit 101 before any line executed; the bound also stops an
+  oversized-but-valid value from spawning a runaway number of concurrent commands (file-descriptor / connection
+  exhaustion). `--parallel 0` (use all logical CPUs) is still accepted.
+- `put-bucket-versioning`, `put-bucket-accelerate-configuration`, and `put-bucket-request-payment` lines missing
+  their required state flag (`--enabled` / `--suspended`, `--requester` / `--bucket-owner`) no longer terminate the
+  whole batch. The validation error previously exited the batch-run process itself mid-run — bypassing
+  `--continue-on-error` and `--max-errors`, skipping every later line, and suppressing the summary. It is now an
+  ordinary per-line failure (same message, same exit code 2) governed by the failure-policy flags like any other
+  invalid line. Standalone invocations of the three subcommands are unchanged.
+
+#### clean
+
+- `clean` no longer panics with exit code 101 when stderr is closed early by a downstream pipe (e.g.
+  `s7cmd clean ... 2>&1 | head`). Writing the final summary or the `Deletion cancelled.` message to the closed pipe
+  aborted the process even though the deletion itself had already succeeded; these writes now tolerate a closed
+  stderr, matching `sync`.
 
 ### Documentation
 
-- Added a "Security assumptions" section to the README, mirroring the sections the upstream PRs added to the
-  s3sync / s3util-rs / s3rm-rs / s3ls-rs READMEs.
+- Added a "Security assumptions" section to the README describing the trust model s7cmd is built on, mirroring the
+  equivalent sections in the s3sync / s3util-rs / s3rm-rs / s3ls-rs READMEs.
 
 ### Changed
 
 - s3sync `v1.59.0 -> v1.60.0`, s3util-rs `v1.7.1 -> v1.8.0`, s3rm-rs `v1.3.8 -> v1.4.0`, s3ls-rs
-  `v1.0.3 -> v1.1.0` (all released 2026-07-20). The fixes previously listed here as "pending upstream releases" are
-  now included. The user-visible changes beyond the sections above:
+  `v1.0.3 -> v1.1.0` (all released 2026-07-20). The user-visible changes these updates bring, beyond the sections
+  above:
   - **cp/mv/s3-to-stdout reads are version-pinned (s3util-rs).** Reads of a source object are pinned to the version
     observed by the initial `HeadObject`, so an overwrite landing mid-download can no longer produce a silently
     truncated copy or interleaved stdout bytes. **IAM impact:** the pinned reads carry a `versionId`, which S3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,14 +16,31 @@ Ports the applicable fixes from s3sync [PR#246](https://github.com/nidor1998/s3s
 `batch-run` / CLI code found in a security review — inline-credential redaction in per-line logs, and a `--parallel`
 upper bound (see **Security** and **Fixed › batch-run** below).
 
+Those upstream PRs have since shipped: this release also updates the pinned libraries to their 2026-07-20 releases —
+s3sync `v1.60.0`, s3util-rs `v1.8.0`, s3rm-rs `v1.4.0`, s3ls-rs `v1.1.0` — bringing in the remaining library-side
+fixes and the new `--transition-default-minimum-object-size` option (see **Added** and **Changed** below), and
+reconciles the vendored runners with the released code (request-payer wiring, lifecycle-flag wiring, and the
+`fs_util::has_trailing_separator` helper).
+
+### Added
+
+#### s3util-rs
+
+- `put-bucket-lifecycle-configuration` gains `--transition-default-minimum-object-size`
+  (`varies_by_storage_class` or `all_storage_classes_128K`), sent to S3 as the request parameter of the same name.
+  S3 accepts the value only as a request parameter — never inside the lifecycle configuration document — so this is
+  the only way to preserve a non-default setting across a get-edit-put roundtrip
+  (see **Fixed › put-bucket-lifecycle-configuration** below).
+
 ### Security
 
 - Credential-related command line options no longer display their values in `--help` output when set via environment
   variables, on every subcommand: access keys, secret access keys, session tokens (`*_ACCESS_KEY`,
   `*_SECRET_ACCESS_KEY`, `*_SESSION_TOKEN`), and SSE-C key material (`*_SSE_C_KEY`, `*_SSE_C_KEY_MD5`). The
-  environment-variable names are still shown. Upstream fixes this in the (unreleased) mains of all four libraries;
-  until those ship in released crates, s7cmd enforces the same `hide_env_values` marking when it builds its clap
-  command tree, which becomes an idempotent no-op once the upstream releases catch up.
+  environment-variable names are still shown. The pinned releases of all four libraries (s3sync `v1.60.0`, s3rm-rs
+  `v1.4.0`, s3ls-rs `v1.1.0`, s3util-rs `v1.8.0`) now carry the same `hide_env_values` marking at the derive level;
+  s7cmd keeps enforcing it when it builds its clap command tree — an idempotent no-op today — as a guard against a
+  future upstream credential argument that misses the marking.
 - `batch-run` no longer echoes inline credential values from a script line into its logs. A per-line command may
   legally carry a credential on the command line (`--target-secret-access-key`, `--source-secret-access-key`,
   `--*-access-key`, `--*-session-token`, `--*-sse-c-key`, `--*-sse-c-key-md5`); batch-run logs each line's raw text as
@@ -49,14 +66,16 @@ upper bound (see **Security** and **Fixed › batch-run** below).
   are still allowed, and an explicit `--source-version-id` (other than `null`) is still accepted as a
   version-promotion operation.
 
-#### put-bucket-lifecycle-configuration (adapted from s3util-rs PR#25)
+#### put-bucket-lifecycle-configuration (from s3util-rs v1.8.0)
 
 - A top-level `TransitionDefaultMinimumObjectSize` key in the input JSON — as produced by
   `get-bucket-lifecycle-configuration` — is now rejected with guidance instead of being silently dropped. S3 accepts
   the value only as a request parameter, never inside the configuration document, so silently dropping it reset a
   bucket configured with `varies_by_storage_class` back to S3's default of `all_storage_classes_128K` on a
-  get-edit-put roundtrip. (Upstream additionally gains a `--transition-default-minimum-object-size` option; that flag
-  arrives in s7cmd with the next s3util-rs release.)
+  get-edit-put roundtrip. With s3util-rs `v1.8.0` the vendored runner adopts the released implementation: the
+  library's input structs reject *every* unknown JSON field (`deny_unknown_fields`), and the runner maps the
+  `TransitionDefaultMinimumObjectSize` rejection to guidance pointing at the new
+  `--transition-default-minimum-object-size` flag (see **Added**), which sends the value the way S3 accepts it.
 
 #### batch-run
 
@@ -71,18 +90,64 @@ upper bound (see **Security** and **Fixed › batch-run** below).
 - Added a "Security assumptions" section to the README, mirroring the sections the upstream PRs added to the
   s3sync / s3util-rs / s3rm-rs / s3ls-rs READMEs.
 
-### Pending upstream releases
+### Changed
 
-The remaining fixes in the referenced PRs live in the upstream *library* code that s7cmd consumes from crates.io
-(`s3sync = 1.59.0`, `s3util-rs = 1.7.1`, `s3rm-rs = 1.3.8`, `s3ls-rs = 1.0.3`), so they reach s7cmd automatically
-when the upstream crates publish releases containing them and the pins are bumped. Notably: `ONEZONE_IA` naming in
-`--storage-class` help/errors, stable same-second object-version replay ordering, SSE-C ETag source parameters,
-delete-marker size/ETag panics, `Expires`/`expiry-date` parse hardening, stricter S3-path and `--metadata`
-validation, annotation-API force-retry (s3sync PR#245); suspended-versioning buckets treated as versioned and
-delete-marker exclusion from attribute filters in `clean` (s3rm-rs PR#94); `--max-parallel-listings` leaf-scan
-enforcement and exact `--rate-limit-api` rates in `ls` (s3ls-rs PR#29); `--target-request-payer` wiring,
-`--transition-default-minimum-object-size`, transfer-verification hardening, and stricter input-JSON validation
-(`deny_unknown_fields`) in the `cp`/`mv`/bucket-admin family (s3util-rs PR#25).
+- s3sync `v1.59.0 -> v1.60.0`, s3util-rs `v1.7.1 -> v1.8.0`, s3rm-rs `v1.3.8 -> v1.4.0`, s3ls-rs
+  `v1.0.3 -> v1.1.0` (all released 2026-07-20). The fixes previously listed here as "pending upstream releases" are
+  now included. The user-visible changes beyond the sections above:
+  - **cp/mv/s3-to-stdout reads are version-pinned (s3util-rs).** Reads of a source object are pinned to the version
+    observed by the initial `HeadObject`, so an overwrite landing mid-download can no longer produce a silently
+    truncated copy or interleaved stdout bytes. **IAM impact:** the pinned reads carry a `versionId`, which S3
+    authorizes against `s3:GetObjectVersion` instead of `s3:GetObject`. Reading from a bucket that has (or ever had)
+    versioning enabled now requires `s3:GetObjectVersion` (plus `s3:GetObjectVersionTagging` where tags are read, and
+    `s3:DeleteObjectVersion` for `mv`); least-privilege policies granting only the unversioned actions will start
+    failing with `AccessDenied`. Unversioned buckets are unaffected; `--source-version-id` still takes precedence.
+  - **`--target-request-payer` is now actually sent** by `rm`, `head-object`, `get-object-tagging`,
+    `put-object-tagging`, `restore-object`, `presign`, and the target-exists probe of `cp --skip-existing` (the flag
+    was previously parsed and discarded, yielding `403` on Requester Pays buckets). The vendored runners wire the
+    parameter through the updated s3util-rs API signatures. For `presign`, `x-amz-request-payer` becomes part of the
+    URL's signature, so whoever fetches the URL must send `x-amz-request-payer: requester` as well.
+  - **`put-*` JSON inputs reject unknown fields (s3util-rs `deny_unknown_fields`),** matching the AWS CLI's "Unknown
+    parameter" behavior. A misspelled or wrongly nested key previously vanished silently and the truncated remainder
+    replaced the whole bucket configuration — most severely, piping `get-public-access-block` output (wrapped in a
+    `PublicAccessBlockConfiguration` key) straight back into `put-public-access-block` parsed as "all four flags
+    absent" and disabled every public-access protection on the bucket.
+  - **`clean` versioning semantics (s3rm-rs).** Versioning-*suspended* buckets are treated as versioned, so
+    `--delete-all-versions` permanently removes historical versions and delete markers instead of degrading to
+    versionless deletes; `--keep-latest-only` and `--filter-delete-marker-only` no longer reject suspended buckets.
+    Delete markers are excluded from the size/content-type/metadata/tag filters (a marker has none of those
+    attributes, and deleting a latest marker resurrects the object it hides); `--filter-delete-marker-only` now
+    conflicts with those filters, and markers no longer abort filtered `--delete-all-versions` runs (the
+    `HeadObject`/`GetObjectTagging` HTTP 405 on a marker version is skipped rather than cancelling the pipeline).
+  - **`ls` listing fidelity (s3ls-rs).** `--max-parallel-listings` is enforced for deep-prefix (leaf) listings —
+    previously the permit was released before each leaf scan, allowing unbounded concurrent `ListObjectsV2` calls —
+    and `--rate-limit-api` enforces the exact requested rate instead of rounding down to a multiple of 10.
+  - **`sync` hardening (s3sync).** `ONEZONE_IA` naming in `--storage-class`/`--annotation-storage-class`; stable
+    object-version ordering when versions share a last-modified second; `--check-etag` with SSE-C uses the *source*
+    SSE-C parameters for the source ETag; `--force-retry-count` applies to `HeadObject` and the object-annotation
+    APIs; a `DeleteMarker` reports size 0 / no ETag instead of panicking; invalid `Expiration`/`Expires` values warn
+    instead of panicking; stricter S3-path-prefix and `--metadata` validation; downloads verify on the temporary file
+    before it is persisted (an object failing verification never becomes visible at the destination).
+  - **`cp`/`mv` transfer verification hardening (s3util-rs).** Buffer sizes derived from server-reported part sizes
+    are validated (a hostile or non-compliant endpoint can no longer force an allocation abort); two reachable panics
+    in the transfer paths now return errors; single-part server-side copies no longer double-count progress bytes;
+    S3-to-stdout ETag/checksum verification computes correct digests incrementally (no spurious exit-3 mismatches, no
+    whole-object buffering); ETag-shape mismatches are explained (`--auto-chunksize` hint) instead of being reported
+    as corruption; `--disable-additional-checksum-verify` is honoured on downloads; `--if-none-match` and the
+    metadata/content-header flags now apply to stdin uploads on both the buffered and multipart paths; downloads
+    verify on the temporary file before persisting, as in `sync`.
+- aws-sdk-s3 `v1.137.0 -> v1.138.1`; the re-exported AWS SDK minors are synced to match the new library releases
+  (aws-config `1.9`, aws-smithy-runtime-api `1.13`, aws-smithy-types `1.6`), keeping the dependency tree unified.
+- MSRV `1.91.1 -> 1.94.1` (required by the updated libraries).
+
+### Underlying libraries
+
+```toml
+s3sync = "=1.60.0"
+s3util-rs = "=1.8.0"
+s3rm-rs = "=1.4.0"
+s3ls-rs = "=1.1.0"
+```
 
 ## [1.5.0] - 2026-07-11
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -95,9 +95,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.103"
+version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
+checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
 
 [[package]]
 name = "arc-swap"
@@ -143,13 +143,13 @@ dependencies = [
 
 [[package]]
 name = "async-trait"
-version = "0.1.89"
+version = "0.1.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
+checksum = "ae36dc4177970ef04fde5178d3e2429882def40e57a451f919c098f72baa6cec"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 3.0.2",
 ]
 
 [[package]]
@@ -166,9 +166,9 @@ checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "aws-config"
-version = "1.8.18"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e33f815b73a3899c03b380d543532e5865f230dce9678d108dc10732a8682275"
+checksum = "47712fde1909402600ccfbb26e47d482d2e58bb9e9e603d9f17e67cc435a6319"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -197,9 +197,9 @@ dependencies = [
 
 [[package]]
 name = "aws-credential-types"
-version = "1.2.14"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f20799b373a1be121fe3005fba0c2090af9411573878f224df44b42727fcaf7"
+checksum = "e93964ffdaf57857f544be3666a5f57570bb699e934700f11b49708f61bb556e"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-runtime-api",
@@ -231,9 +231,9 @@ dependencies = [
 
 [[package]]
 name = "aws-runtime"
-version = "1.7.5"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c9b9de216a988dd54b754a82a7660cfe14cee4f6782ae4524470972fa0ccb39"
+checksum = "7816e98ee912159f45d307e5ee6bfea4a335a55aee15f7f3e32f81a6f3000f1d"
 dependencies = [
  "aws-credential-types",
  "aws-sigv4",
@@ -259,9 +259,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-s3"
-version = "1.137.0"
+version = "1.138.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2dd7213994e2ff9382ff100403b78c30d1b74cdfcd8fa9d0d1dc3a94a5c4874"
+checksum = "8fa59420755799fec8aac71f562aa37ba82263f5b1926bba8b5d3465d2f7a73f"
 dependencies = [
  "arc-swap",
  "aws-credential-types",
@@ -275,6 +275,7 @@ dependencies = [
  "aws-smithy-observability",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
+ "aws-smithy-schema",
  "aws-smithy-types",
  "aws-smithy-xml",
  "aws-types",
@@ -295,9 +296,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-sso"
-version = "1.102.0"
+version = "1.103.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c82b3ac19f1431854f7ace3a7531674633e286bfdde21976893bfee36fd493b"
+checksum = "0469f435f645ad2162cfb463b15bde37115966ee3acf2d87fb4871ee309b8401"
 dependencies = [
  "arc-swap",
  "aws-credential-types",
@@ -308,6 +309,7 @@ dependencies = [
  "aws-smithy-observability",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
+ "aws-smithy-schema",
  "aws-smithy-types",
  "aws-types",
  "bytes",
@@ -320,9 +322,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-ssooidc"
-version = "1.104.0"
+version = "1.105.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "321000d2b4c5519ee573f73167f612efd7329322d9b26969ad1979f0427f1913"
+checksum = "085faefb253f770655e162b9304321e62a1e71adf7f019ee1f4454228a377b3a"
 dependencies = [
  "arc-swap",
  "aws-credential-types",
@@ -333,6 +335,7 @@ dependencies = [
  "aws-smithy-observability",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
+ "aws-smithy-schema",
  "aws-smithy-types",
  "aws-types",
  "bytes",
@@ -345,9 +348,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-sts"
-version = "1.107.0"
+version = "1.108.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d0d328ba962af23ecfa3c9f23b98d3d35e325fa218d7f13d17a6bf522f8a560"
+checksum = "3c72b08911d8128dd360fe1b22a9fec0fa8b552dde8ec828dcf20ef5ec974e9f"
 dependencies = [
  "arc-swap",
  "aws-credential-types",
@@ -359,6 +362,7 @@ dependencies = [
  "aws-smithy-query",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
+ "aws-smithy-schema",
  "aws-smithy-types",
  "aws-smithy-xml",
  "aws-types",
@@ -371,9 +375,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sigv4"
-version = "1.4.5"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bae38512beae0ffee7010fc24e7a8a123c53efdfef42a61e80fda4882418dc71"
+checksum = "723c2234ad7511ceef63eab016b7ba6ff7c55590fefb96fa8467af014a07309f"
 dependencies = [
  "aws-credential-types",
  "aws-smithy-eventstream",
@@ -398,9 +402,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-async"
-version = "1.2.14"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ffcaf626bdda484571968400c326a244598634dc75fd451325a54ad1a59acfc"
+checksum = "f02e407fb3b54891734224b9ffac8a71fdd35f542500fa1af95754a6b2beb316"
 dependencies = [
  "futures-util",
  "pin-project-lite",
@@ -409,9 +413,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-checksums"
-version = "0.64.8"
+version = "0.65.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9e8e65f4f81fcccdeb6c3eca2af17ac21d421a1786a26a394aecf421d616d3a"
+checksum = "b67ecd999972b58e67cab052f5129906c08c25883bd0788ceefc55ef97d61307"
 dependencies = [
  "aws-smithy-http",
  "aws-smithy-types",
@@ -430,9 +434,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-eventstream"
-version = "0.60.21"
+version = "0.61.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78d8391e65fcea47c586a22e1a41f173b38615b112b2c6b7a44e80cec3e6b706"
+checksum = "5a9381123ab62d20c13082b151f30f962a3b112b727345394536dfa39a482944"
 dependencies = [
  "aws-smithy-types",
  "bytes",
@@ -441,9 +445,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-http"
-version = "0.63.6"
+version = "0.64.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba1ab2dc1c2c3749ead27180d333c42f11be8b0e934058fb4b2258ee8dbe5231"
+checksum = "37843d9add67c3aff5856f409c6dc315d3cdff60f9c0cb5b670dab1e9920306d"
 dependencies = [
  "aws-smithy-eventstream",
  "aws-smithy-runtime-api",
@@ -463,9 +467,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-http-client"
-version = "1.1.13"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c3ef8931ad1c98aa6a55b4256f847f3116090819844e0dd41ea682cac5dd2d3"
+checksum = "635d23afda0a6ab48d666c4d447c4873e8d1e83518a2be2093122397e50b838e"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-runtime-api",
@@ -487,9 +491,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-json"
-version = "0.62.7"
+version = "0.63.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "701a947f4797e52a911e114a898667c746c39feea467bbd1abd7b3721f702ffa"
+checksum = "3dc65a121adb4b33729919fcfa14fa36fb33c1555a8f06bb0e2188dbfdc1d9ef"
 dependencies = [
  "aws-smithy-runtime-api",
  "aws-smithy-schema",
@@ -498,18 +502,18 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-observability"
-version = "0.2.6"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a06c2315d173edbf1920da8ba3a7189695827002e4c0fc961973ab1c54abca9c"
+checksum = "8e86338c869539a581bf161247762a6e87f92c5c075060057b5ed6d06632ed0c"
 dependencies = [
  "aws-smithy-runtime-api",
 ]
 
 [[package]]
 name = "aws-smithy-query"
-version = "0.60.15"
+version = "0.61.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a56d79744fb3edb5d722ef79d86081e121d3b9422cb209eb03aea6aa4f21ebd"
+checksum = "dd22a6ba36e3f113cb8d5b3d1fe0ed31c76ee608ef63322d753bb8d2c9479e77"
 dependencies = [
  "aws-smithy-types",
  "urlencoding",
@@ -517,9 +521,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-runtime"
-version = "1.11.3"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8e6f5caf6fea86f8c2206541ab5857cfcda9013426cdbe8fa0098b9e2d32182"
+checksum = "bea94a9ff8464016338c851e24b472d7131c388c88898a502e781815b2ee6045"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-http",
@@ -543,9 +547,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-runtime-api"
-version = "1.12.3"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9db177daa6ba8afb9ee1aefcf548c907abcf52065e394ee11a92780057fe0e8c"
+checksum = "22ed1ebe6e0a95ea84570225f5a8208dec4b8f77e61a9b0d6f51773fcb4612f0"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-runtime-api-macros",
@@ -561,9 +565,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-runtime-api-macros"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d7396fd9500589e62e460e987ecb671bad374934e55ec3b5f498cc7a8a8a7b7"
+checksum = "221eaa237ddf1ca79b60d1372aad77e47f9c0ea5b3ce5099da8c61d027dc77b3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -572,9 +576,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-schema"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7442cb268338f0eb8278140a107c046756aa01093d8ef5e99628d34ae09c94f5"
+checksum = "7d56e0a4e53127a632224e43633b0fe045fa9e1e3cfc68b9830f1115e103f910"
 dependencies = [
  "aws-smithy-runtime-api",
  "aws-smithy-types",
@@ -583,9 +587,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-types"
-version = "1.5.0"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32b42fcf341259d85ca10fac9a2f6448a8ec691c6955a18e45bc3b71a85fab85"
+checksum = "d6dc683efb34b9e755675b37fedbe0103141e5b6df7bdc9eb6967756a8c167d8"
 dependencies = [
  "base64-simd",
  "bytes",
@@ -609,9 +613,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-types-convert"
-version = "0.60.14"
+version = "0.61.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e50da9f5e3ecf145b4f6eb04963e6fbf52f528017de0784a28c56b9407414b1"
+checksum = "f09916ff010d43086d52ec7d38899a5bc2ad21a2cb5428f85f1ee84a44008ba0"
 dependencies = [
  "aws-smithy-types",
  "chrono",
@@ -619,18 +623,21 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-xml"
-version = "0.60.15"
+version = "0.61.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ce02add1aa3677d022f8adf81dcbe3046a95f17a1b1e8979c145cd21d3d22b3"
+checksum = "ea3f68eec3607f02acd24067969ce2abc6ba16aa7d5ce59ca450ed2fb5f78957"
 dependencies = [
+ "aws-smithy-runtime-api",
+ "aws-smithy-schema",
+ "aws-smithy-types",
  "xmlparser",
 ]
 
 [[package]]
 name = "aws-types"
-version = "1.3.16"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d16bf10b03a3c01e6b3b7d47cd964e873ffe9e7d4e80fad16bd4c077cb068531"
+checksum = "e957a6c6dbce82b7a91f44231c09273159703769f447cbe85e854dfe9cf67f86"
 dependencies = [
  "aws-credential-types",
  "aws-smithy-async",
@@ -692,9 +699,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.13.0"
+version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
+checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
 
 [[package]]
 name = "bitvec"
@@ -769,9 +776,9 @@ checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
 name = "byte-unit"
-version = "5.2.3"
+version = "5.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37bcaa4a0975bed4a760af3efe4368825098ce5f9d37a30c5a021d635dc63d8f"
+checksum = "4a813de7f2bbedb7dce265b64f1cf5908ebe4d56281ece8d847e98113788b9b0"
 dependencies = [
  "rust_decimal",
  "schemars",
@@ -856,9 +863,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.6.1"
+version = "4.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
+checksum = "dd059f9da4f5c36b3787f65d38ccaab1cc315f07b01f89abc8359ee6a8205011"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -876,9 +883,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.6.0"
+version = "4.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
+checksum = "f09628afdcc538b57f3c6341e9c8e9970f18e4a481690a64974d7023bd33548b"
 dependencies = [
  "anstream",
  "anstyle",
@@ -889,9 +896,9 @@ dependencies = [
 
 [[package]]
 name = "clap_complete"
-version = "4.6.5"
+version = "4.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0a7a9bfdb35811f9e59832f0f05975114d2251b415fb534108e6f34060fd772"
+checksum = "db8b397918185f0161ff3d6fcaa9e4bfc09b8367caf6e1d4a2848e5477ed027b"
 dependencies = [
  "clap",
 ]
@@ -946,9 +953,9 @@ dependencies = [
 
 [[package]]
 name = "console"
-version = "0.16.3"
+version = "0.16.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d64e8af5551369d19cf50138de61f1c42074ab970f74e99be916646777f8fc87"
+checksum = "4fe5f465a4f6fee88fad41b85d990f84c835335e85b5d9e6e63e0d06d28cba7c"
 dependencies = [
  "encode_unicode",
  "libc",
@@ -1398,9 +1405,9 @@ checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "futures"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
+checksum = "a88cf1f829d945f548cf8fec32c61b1f202b6d93b45848602fc02af4b12ad218"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1413,9 +1420,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
+checksum = "262590f4fe6afeb0bc83be1daa64e52657fe185690a958af7f3ad0e92085c5ae"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -1423,15 +1430,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+checksum = "2cd50c473c80f6d7c3670a752354b8e569b1a7cbfdc0419ec88e5edad85e0dc7"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
+checksum = "6754879cc9f2c66f88c6e5c35344bb0bdb0708b0352b1201815667c7eabc7458"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -1440,15 +1447,15 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
+checksum = "4577ecaa3c4f96589d473f679a71b596316f6641bc350038b962a5daf0085d7a"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
+checksum = "2d6d3cde68c518367be28956066ddfef33813991b77a55005a69dae04bf3b10b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1457,21 +1464,21 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
+checksum = "e34418ac499d6305c2fb5ad0ed2f6ac998c5f8ca209b4510f7f94242c647e307"
 
 [[package]]
 name = "futures-task"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+checksum = "b231ed28831efb4a61a08580c4bc233ec56bc009f4cd8f52da2c3cb97df0c109"
 
 [[package]]
 name = "futures-util"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+checksum = "a77a90a256fce34da66415271e30f94ee91c57b04b8a2c042d9cf3220179deaa"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1535,7 +1542,7 @@ version = "0.20.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b88256088d75a56f8ecfa070513a775dd9107f6530ef14919dac831af9cfe2b"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "libc",
  "libgit2-sys",
  "log",
@@ -1672,9 +1679,9 @@ dependencies = [
 
 [[package]]
 name = "http-body-util"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
+checksum = "e9f41fd6a08e4d4ec69df65976da761afd5ad5e58a9d4acb46bd1c953a9e3ff2"
 dependencies = [
  "bytes",
  "futures-core",
@@ -1897,9 +1904,9 @@ dependencies = [
 
 [[package]]
 name = "indicatif"
-version = "0.18.4"
+version = "0.18.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25470f23803092da7d239834776d653104d551bc4d7eacaf31e6837854b8e9eb"
+checksum = "9433806cd6b4ec1aba79c021c7e4c58fb4c3b9977c085062e611ac929998fb0c"
 dependencies = [
  "console",
  "portable-atomic",
@@ -2095,18 +2102,18 @@ dependencies = [
 
 [[package]]
 name = "lua-src"
-version = "550.0.0"
+version = "550.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e836dc8ae16806c9bdcf42003a88da27d163433e3f9684c52f0301258004a4fb"
+checksum = "75c110c2fa33f34e0de05448e1f3eb2e0631e7a69e2d8ae1586cffc9fc9f9949"
 dependencies = [
  "cc",
 ]
 
 [[package]]
 name = "luajit-src"
-version = "210.6.6+707c12b"
+version = "210.7.2+b925b3e"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a86cc925d4053d0526ae7f5bc765dbd0d7a5d1a63d43974f4966cb349ca63295"
+checksum = "920cf654b23d217c550ceea57c32cd2a413ea27b6d47ed77b5ee0cf655adefa6"
 dependencies = [
  "cc",
  "which",
@@ -2133,9 +2140,9 @@ dependencies = [
 
 [[package]]
 name = "md5"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae960838283323069879657ca3de837e9f7bbb4c7bf6ea7f1b290d5e9476d2e0"
+checksum = "7ebb8d8732c6a6df3d8f032a82911cfc747e00efb95cc46e8d0acd5b5b88570c"
 
 [[package]]
 name = "memchr"
@@ -2182,9 +2189,9 @@ dependencies = [
 
 [[package]]
 name = "mlua"
-version = "0.11.6"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccd36acfa49ce6ee56d1307a061dd302c564eee757e6e4cd67eb4f7204846fab"
+checksum = "ad72ffa037cf5970c9860674f32f703fda25d86cf217475fe7a79c5f9961bcaa"
 dependencies = [
  "bstr",
  "either",
@@ -2194,14 +2201,13 @@ dependencies = [
  "num-traits",
  "parking_lot",
  "rustc-hash",
- "rustversion",
 ]
 
 [[package]]
 name = "mlua-sys"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f1c3a7fc7580227ece249fd90aa2fa3b39eb2b49d3aec5e103b3e85f2c3dfc8"
+checksum = "92136787b906d4e55cfe96cd6c62e010bb1a56889d0d6cf83eb016dbad07576b"
 dependencies = [
  "cc",
  "cfg-if",
@@ -2217,7 +2223,7 @@ version = "0.31.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "cfg-if",
  "cfg_aliases",
  "libc",
@@ -2626,7 +2632,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
 ]
 
 [[package]]
@@ -2651,9 +2657,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.12.4"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1292b7759ae1cb9ec195452d1390a074f0cd8541ab7a5a8c31cd6db45d4a6ba"
+checksum = "f020237b6c8eed93db2e2cb53c00c60a8e1bc73da7d073199a1180401450218d"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -2663,9 +2669,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.14"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+checksum = "8fcfdb36bda0c880c5931cdc7a2bcdc8ba4556847b9d912bca70bc94708711ad"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -2784,7 +2790,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -2866,9 +2872,9 @@ checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "s3ls-rs"
-version = "1.0.3"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9512db9c79d445e41ba705b1cd76f301f4d3a19ad0bd823ce75e8293403f8d4"
+checksum = "1734e45cddb7916945f830441779d9a980dc27ccdaa8a388d9898bade1d01fcd"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2902,9 +2908,9 @@ dependencies = [
 
 [[package]]
 name = "s3rm-rs"
-version = "1.3.8"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd62a72141e8c40a1d882aa5d8f768a028779238f158fbeb95b9bb9d5a0e908a"
+checksum = "89fed70cc0f10da6541d03fe6f1c0146c97abdbaa4f2eb557c89a3dd27d025cf"
 dependencies = [
  "anyhow",
  "async-channel",
@@ -2916,7 +2922,7 @@ dependencies = [
  "aws-smithy-types",
  "aws-smithy-types-convert",
  "aws-types",
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "byte-unit",
  "cfg-if",
  "chrono",
@@ -2944,9 +2950,9 @@ dependencies = [
 
 [[package]]
 name = "s3sync"
-version = "1.59.0"
+version = "1.60.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84daeb9f5d124ebf2c9b6aed339e1d78e48e8ae8ba30b289c507a05363c510f9"
+checksum = "1653378798b45cbf555361b287b226d120ddc97f8d5390108fbf5699d7ec14d0"
 dependencies = [
  "anyhow",
  "async-channel",
@@ -2959,7 +2965,7 @@ dependencies = [
  "aws-smithy-types-convert",
  "aws-types",
  "base64",
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "byte-unit",
  "cfg-if",
  "chrono",
@@ -3006,9 +3012,9 @@ dependencies = [
 
 [[package]]
 name = "s3util-rs"
-version = "1.7.1"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82e5511aaf9c2914fb38558689b3190cff2481b3f7d1785865ec5d74325738b6"
+checksum = "99116d2992cdbaa894f23e66b2e1d082beb63d12d4cefb0b94b1cb6d83ef4468"
 dependencies = [
  "anyhow",
  "async-channel",
@@ -3021,7 +3027,7 @@ dependencies = [
  "aws-smithy-types-convert",
  "aws-types",
  "base64",
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "byte-unit",
  "cfg-if",
  "chrono",
@@ -3065,7 +3071,7 @@ dependencies = [
 
 [[package]]
 name = "s7cmd"
-version = "1.5.0"
+version = "1.6.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -3166,7 +3172,7 @@ version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "core-foundation",
  "core-foundation-sys",
  "libc",
@@ -3191,9 +3197,9 @@ checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+checksum = "4148590afebada386688f18773da617792bf2ef03ffc1e4cbd2b1d45b023e0ba"
 dependencies = [
  "serde_core",
  "serde_derive",
@@ -3201,29 +3207,29 @@ dependencies = [
 
 [[package]]
 name = "serde_core"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+checksum = "67dca2c9c51e58a4791a4b1ed58308b39c64224d349a935ab5039aa360942a48"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 3.0.2",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.150"
+version = "1.0.151"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
+checksum = "c841b55ecdae098c80dcae9cf767f6f8a0c2cdb3416bbef72181df4d0fe73f14"
 dependencies = [
  "itoa",
  "memchr",
@@ -3423,6 +3429,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "syn"
+version = "3.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a207d6d6a2b7fc470b80443726053f18a2481b7e1eee970597051596567987a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
 name = "synstructure"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3470,22 +3487,22 @@ checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
 name = "thiserror"
-version = "2.0.18"
+version = "2.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+checksum = "09a43598840e33d5b0331f38c5e30d13bb11c11210a4b58f0d9b18a5a5eefcd9"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.18"
+version = "2.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
+checksum = "43cbfe0cf76104d42a574802844187e84a305e531ed54455f11fbde0f10541cd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 3.0.2",
 ]
 
 [[package]]
@@ -3556,9 +3573,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.52.3"
+version = "1.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
+checksum = "d988bcd52dbe076d3d46903332f58c912b87a2c49b1428419a5845154762ffee"
 dependencies = [
  "bytes",
  "libc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -101,18 +101,18 @@ checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
 
 [[package]]
 name = "arc-swap"
-version = "1.9.1"
+version = "1.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a3a1fd6f75306b68087b831f025c712524bcb19aad54e557b1129cfa0a2b207"
+checksum = "c049c0be4daef0b145cb3555416b3b8ef5b7888a38aea1a3a155801fe7b0810b"
 dependencies = [
  "rustversion",
 ]
 
 [[package]]
 name = "arrayvec"
-version = "0.7.7"
+version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f02882884d3e1bc524fb12c79f107f6ad0e1cfd498c536ffb494301740995dfe"
+checksum = "d3fb67a6e08acf24fdeccbac2cb6ac4305825bd1f117462e0e6f2f193345ad56"
 
 [[package]]
 name = "assert_cmd"
@@ -187,7 +187,7 @@ dependencies = [
  "fastrand",
  "hex",
  "http 1.4.2",
- "sha1 0.10.6",
+ "sha1 0.10.7",
  "time",
  "tokio",
  "tracing",
@@ -209,9 +209,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.17.0"
+version = "1.17.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ec2f1fc3ec205783a5da9a7e6c1509cc69dedf09a1949e412c1e18469326d00"
+checksum = "00bdb5da18dac48ca2cc7cd4a98e533e8635a58e2361d13a1a4ee3888e0d72f1"
 dependencies = [
  "aws-lc-sys",
  "zeroize",
@@ -219,14 +219,15 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.41.0"
+version = "0.43.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a2f9779ce85b93ab6170dd940ad0169b5766ff848247aff13bb788b832fe3f4"
+checksum = "43103168cc76fe62678a375e722fc9cb3a0146159ac5828bc4f0dfd755c2224c"
 dependencies = [
  "cc",
  "cmake",
  "dunce",
  "fs_extra",
+ "pkg-config",
 ]
 
 [[package]]
@@ -250,7 +251,7 @@ dependencies = [
  "http 0.2.12",
  "http 1.4.2",
  "http-body 0.4.6",
- "http-body 1.0.1",
+ "http-body 1.1.0",
  "percent-encoding",
  "pin-project-lite",
  "tracing",
@@ -285,7 +286,7 @@ dependencies = [
  "hmac 0.13.0",
  "http 0.2.12",
  "http 1.4.2",
- "http-body 1.0.1",
+ "http-body 1.1.0",
  "lru",
  "percent-encoding",
  "regex-lite",
@@ -423,7 +424,7 @@ dependencies = [
  "crc-fast",
  "hex",
  "http 1.4.2",
- "http-body 1.0.1",
+ "http-body 1.1.0",
  "http-body-util",
  "md-5",
  "pin-project-lite",
@@ -457,7 +458,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "http 1.4.2",
- "http-body 1.0.1",
+ "http-body 1.1.0",
  "http-body-util",
  "percent-encoding",
  "pin-project-lite",
@@ -537,7 +538,7 @@ dependencies = [
  "http 0.2.12",
  "http 1.4.2",
  "http-body 0.4.6",
- "http-body 1.0.1",
+ "http-body 1.1.0",
  "http-body-util",
  "pin-project-lite",
  "pin-utils",
@@ -571,7 +572,7 @@ checksum = "221eaa237ddf1ca79b60d1372aad77e47f9c0ea5b3ce5099da8c61d027dc77b3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -598,7 +599,7 @@ dependencies = [
  "http 0.2.12",
  "http 1.4.2",
  "http-body 0.4.6",
- "http-body 1.0.1",
+ "http-body 1.1.0",
  "http-body-util",
  "itoa",
  "num-integer",
@@ -735,9 +736,9 @@ dependencies = [
 
 [[package]]
 name = "borsh"
-version = "1.7.0"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f3f6da4992df95bbcd9af42a6c7dcb994498fc9048230405f3b36ff7cd3f145"
+checksum = "a88b7ea17d208c4193f2c1e6de3c35fe71f98c96982d5ced308bdcc749ff6e1f"
 dependencies = [
  "borsh-derive",
  "bytes",
@@ -746,22 +747,22 @@ dependencies = [
 
 [[package]]
 name = "borsh-derive"
-version = "1.7.0"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ae8fb4fb5740e4b2c4884ff95f5f32f5e8479db1e8fd8eb49ddbe09eb09bb7c"
+checksum = "d8f347189c62a579b8cd5f80714efa178f52e461dc2e6d701d264f5ff22e566c"
 dependencies = [
  "once_cell",
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "bstr"
-version = "1.12.3"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cee35f73844aa3014bb606320a6c1f010249dbdf43342fe54b5a4f6a8ed4b79"
+checksum = "1f7dc094d718f2e1c1559ad110e27eeaae14a5465d3d56dd6dbd793079fbd530"
 dependencies = [
  "memchr",
  "regex-automata",
@@ -810,9 +811,9 @@ dependencies = [
 
 [[package]]
 name = "bytes"
-version = "1.12.0"
+version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ae3f5d315924270530207e2a68396c3cc547f6dca3fbdca317cfb1a51edb593"
+checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
 
 [[package]]
 name = "bytes-utils"
@@ -826,9 +827,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.65"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e228eec9be7c17ccb640b59b36a5cd805ea2a564a4c5e162c2f659fea30d3b96"
+checksum = "c89588d05638b5b4594a3348a2d6c20277e43a7f5c5202b05cc56888475a47b8"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -844,9 +845,9 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "cfg_aliases"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+checksum = "f079e83a288787bcd14a6aea84cee5c87a67c5a3e660c30f557a3d24761b3527"
 
 [[package]]
 name = "chrono"
@@ -912,7 +913,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1060,9 +1061,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-deque"
-version = "0.8.6"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+checksum = "5181e0de7b61eb03a81e347d6dd8797bae9da5146707b51077e2d71a54ec0ceb"
 dependencies = [
  "crossbeam-epoch",
  "crossbeam-utils",
@@ -1079,9 +1080,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.21"
+version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+checksum = "61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17"
 
 [[package]]
 name = "crypto-bigint"
@@ -1125,9 +1126,9 @@ dependencies = [
 
 [[package]]
 name = "defmt"
-version = "1.1.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6e524506490a1953d237cb87b1cfc1e46f88c18f10a22dfe0f507dc6bfc7f7f"
+checksum = "e2953bfe4f93bbd20cc71198842756f77d161884c99ebbabc41d80231ded88d1"
 dependencies = [
  "bitflags 1.3.2",
  "defmt-macros",
@@ -1135,15 +1136,14 @@ dependencies = [
 
 [[package]]
 name = "defmt-macros"
-version = "1.1.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0a27770e9c8f719a79d8b638281f4d828f77d8fd61e0bd94451b9b85e576a0b"
+checksum = "bad9c72e7ca2137e0dc3813245a0d282fd6daad32fd800af018306a9169b5fe8"
 dependencies = [
  "defmt-parser",
- "proc-macro-error2",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1210,7 +1210,7 @@ checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1321,9 +1321,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.4.1"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
 
 [[package]]
 name = "ff"
@@ -1459,7 +1459,7 @@ checksum = "2d6d3cde68c518367be28956066ddfef33813991b77a55005a69dae04bf3b10b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1515,25 +1515,13 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
-dependencies = [
- "cfg-if",
- "libc",
- "r-efi 5.3.0",
- "wasip2",
-]
-
-[[package]]
-name = "getrandom"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi 6.0.0",
+ "r-efi",
 ]
 
 [[package]]
@@ -1669,9 +1657,9 @@ dependencies = [
 
 [[package]]
 name = "http-body"
-version = "1.0.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
+checksum = "ca2a8f2913ee65f60facd6a5905613afaa448497a0230cc41ce022d93290bc2c"
 dependencies = [
  "bytes",
  "http 1.4.2",
@@ -1686,7 +1674,7 @@ dependencies = [
  "bytes",
  "futures-core",
  "http 1.4.2",
- "http-body 1.0.1",
+ "http-body 1.1.0",
  "pin-project-lite",
 ]
 
@@ -1698,9 +1686,9 @@ checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
 name = "hybrid-array"
-version = "0.4.12"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9155a582abd142abc056962c29e3ce5ff2ad5469f4246b537ed42c5deba857da"
+checksum = "818356c5132c1fede50f837ca96afbe78ff42413047f4abb886217845e1b6c8c"
 dependencies = [
  "typenum",
 ]
@@ -1717,7 +1705,7 @@ dependencies = [
  "futures-core",
  "h2",
  "http 1.4.2",
- "http-body 1.0.1",
+ "http-body 1.1.0",
  "httparse",
  "itoa",
  "pin-project-lite",
@@ -1753,7 +1741,7 @@ dependencies = [
  "futures-channel",
  "futures-util",
  "http 1.4.2",
- "http-body 1.0.1",
+ "http-body 1.1.0",
  "hyper",
  "ipnet",
  "libc",
@@ -1941,11 +1929,12 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jiff"
-version = "0.2.29"
+version = "0.2.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34f877a98676d2fb664698d74cc6a51ce6c484ce8c770f05d0108ec9090aeb46"
+checksum = "e184d09547b80eb7e20d141ba2fb1fbac843ca53f4cf1b31210adc4c1adc6e16"
 dependencies = [
  "defmt",
+ "jiff-core",
  "jiff-static",
  "jiff-tzdb-platform",
  "log",
@@ -1956,21 +1945,31 @@ dependencies = [
 ]
 
 [[package]]
-name = "jiff-static"
-version = "0.2.29"
+name = "jiff-core"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0666b5ab5ecaca213fc2a85b8c0083d9004e84ee2d5f9a7e0017aaf50986f25f"
+checksum = "7feca88439efe53da3754500c1851dedf3cb36c524dd5cf8225cc0794de95d09"
 dependencies = [
+ "defmt",
+]
+
+[[package]]
+name = "jiff-static"
+version = "0.2.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "323da076b7a6faf914dc677cb05a4b907742ff7375c8322c9e7f5061e5e0e9de"
+dependencies = [
+ "jiff-core",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "jiff-tzdb"
-version = "0.1.6"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c900ef84826f1338a557697dc8fc601df9ca9af4ac137c7fb61d4c6f2dfd3076"
+checksum = "142bd39932ad231f10513df9ab62661fead8719872150b7ad02a2df79f4e141e"
 
 [[package]]
 name = "jiff-tzdb-platform"
@@ -1983,11 +1982,11 @@ dependencies = [
 
 [[package]]
 name = "jobserver"
-version = "0.1.34"
+version = "0.1.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+checksum = "1c00acbd29eabad4a2392fa0e921c874934dbbf4194312ad20f04a0ed67a3cb3"
 dependencies = [
- "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "libc",
 ]
 
@@ -2146,9 +2145,9 @@ checksum = "7ebb8d8732c6a6df3d8f032a82911cfc747e00efb95cc46e8d0acd5b5b88570c"
 
 [[package]]
 name = "memchr"
-version = "2.8.2"
+version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
+checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "mime"
@@ -2178,9 +2177,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
+checksum = "30d65c71f1ce40ab09135ce117d742b9f8a19ff91a41a8b57ed50bc2de59c427"
 dependencies = [
  "libc",
  "wasi",
@@ -2374,7 +2373,7 @@ checksum = "c96395f0a926bc13b1c17622aaddda1ecb55d49c8f1bf9777e4d877800a43f8b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2407,9 +2406,9 @@ checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "portable-atomic"
-version = "1.13.1"
+version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
+checksum = "3d20d5497ef88037a52ff98267d066e7f11fcc5e99bbfbd58a42336193aacec3"
 
 [[package]]
 name = "portable-atomic-util"
@@ -2493,32 +2492,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "proc-macro-error-attr2"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5"
-dependencies = [
- "proc-macro2",
- "quote",
-]
-
-[[package]]
-name = "proc-macro-error2"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802"
-dependencies = [
- "proc-macro-error-attr2",
- "proc-macro2",
- "quote",
- "syn 2.0.118",
-]
-
-[[package]]
 name = "proc-macro2"
-version = "1.0.106"
+version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
+checksum = "985e7ec9bb745e6ce6535b544d84d6cd6f7ad8bd711c398938ae983b91a766d9"
 dependencies = [
  "unicode-ident",
 ]
@@ -2551,18 +2528,12 @@ checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quote"
-version = "1.0.46"
+version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfbc457d0c7a0759a614551b11a6409e5951f6c7537be1f1b7682b9ae9230368"
+checksum = "1fbf4db142a473a8d80c26bbf18454ed458bf8d26c8219c331daecfdbd079001"
 dependencies = [
  "proc-macro2",
 ]
-
-[[package]]
-name = "r-efi"
-version = "5.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "r-efi"
@@ -2578,9 +2549,9 @@ checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "rand"
-version = "0.8.6"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
+checksum = "22f6172bdec972074665ed81ed53b71da00bfc44b65a753cfde883ec4c702a1a"
 dependencies = [
  "libc",
  "rand_chacha",
@@ -2637,22 +2608,22 @@ dependencies = [
 
 [[package]]
 name = "ref-cast"
-version = "1.0.25"
+version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f354300ae66f76f1c85c5f84693f0ce81d747e2c3f21a45fef496d89c960bf7d"
+checksum = "216e8f773d7923bcba9ceb86a86c93cabb3903a11872fc3f138c49630e50b96d"
 dependencies = [
  "ref-cast-impl",
 ]
 
 [[package]]
 name = "ref-cast-impl"
-version = "1.0.25"
+version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
+checksum = "2c9283685feec7d69af75fb0e858d5e7378f33fe4fc699383b2916ab9273e03c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 3.0.2",
 ]
 
 [[package]]
@@ -2771,9 +2742,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-hash"
-version = "2.1.2"
+version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
+checksum = "6b1e7f9a428571be2dc5bc0505c13fb6bf936822b894ec87abf8a08a4e51742d"
 
 [[package]]
 name = "rustc_version"
@@ -2799,9 +2770,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.41"
+version = "0.23.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b92b125634d9b795e7beca796cc790df15a7fb38323bf3196fda83292d06b1f"
+checksum = "3c54fcab019b409d04215d3a17cb438fd7fbf192ee61461f20f4fe18704bc138"
 dependencies = [
  "aws-lc-rs",
  "log",
@@ -2827,9 +2798,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.14.1"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
+checksum = "764899a24af3980067ee14bc143654f297b22eaebfe3c7b6b211920a5a59b046"
 dependencies = [
  "zeroize",
 ]
@@ -2848,9 +2819,9 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.22"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
 
 [[package]]
 name = "rusty-fork"
@@ -3240,9 +3211,9 @@ dependencies = [
 
 [[package]]
 name = "sha1"
-version = "0.10.6"
+version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+checksum = "a978451301f4db1d02937a4ab3ccce137717b81826e79b7d49ffe3244a13c3b8"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
@@ -3331,9 +3302,9 @@ dependencies = [
 
 [[package]]
 name = "simd-adler32"
-version = "0.3.9"
+version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
+checksum = "3a219298ac11a56ea9a6d2120044824d6f01aeb034955e7af7bc16858527deea"
 
 [[package]]
 name = "simdutf8"
@@ -3364,9 +3335,9 @@ checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 
 [[package]]
 name = "socket2"
-version = "0.6.4"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
+checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
@@ -3374,9 +3345,9 @@ dependencies = [
 
 [[package]]
 name = "spin"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5fe4ccb98d9c292d56fec89a5e07da7fc4cf0dc11e156b41793132775d3e591"
+checksum = "023a211cb3138dbc438680b32560ad89f699977624c9f8dbb95a47d5b4c07dd3"
 
 [[package]]
 name = "spki"
@@ -3419,9 +3390,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.118"
+version = "2.0.119"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b9ae57f904213ebb649ce6895b8a66c66f0203b9319718f69a5612a065b1422"
+checksum = "872831b642d1a07999a962a351ed35b955ea2cfc8f3862091e2a240a84f17297"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3447,7 +3418,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -3507,18 +3478,18 @@ dependencies = [
 
 [[package]]
 name = "thread_local"
-version = "1.1.9"
+version = "1.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+checksum = "1ad99c4c6d32803332c548b1af0540b357b3f5fc0be8f6c6bfe8b2e6ae784070"
 dependencies = [
  "cfg-if",
 ]
 
 [[package]]
 name = "time"
-version = "0.3.51"
+version = "0.3.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85c17d80feb7334b40c484e45ed1a5273dfd8bfda537c3be2e74a06a6686f327"
+checksum = "3e1d5e639ff6bab73cb6885cc7e7b1de96c3f32c68ec55f3952614bec1092244"
 dependencies = [
  "deranged",
  "libc",
@@ -3538,9 +3509,9 @@ checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
 
 [[package]]
 name = "time-macros"
-version = "0.2.30"
+version = "0.2.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcef1a61bdb119096e153208ec5cbec23944ce8bca13be5c7f60c634f7403935"
+checksum = "7e689342a48d2ea927c87ea50cabf8594854bf940e9310208848d680d668ed85"
 dependencies = [
  "num-conv",
  "time-core",
@@ -3558,9 +3529,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
+checksum = "bb4ebadaa0af04fab11ae01eb5f9fdb5f9c5b875506e210e71c07873528baa7f"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -3590,13 +3561,13 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.7.0"
+version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
+checksum = "6328af13490e73a9b4694030fafd93f8c8c6a9dede33e821c3fc63eddf8042ba"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -3633,9 +3604,9 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.25.12+spec-1.1.0"
+version = "0.25.13+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2153edc6955a6c354fad8f5efd38b6a8769bdccf9fe50f8e1329f81b0baa5d7"
+checksum = "6975367e4d2ef766d86af01ffad14b622fecc8d4357a998fbc4deb6e9bacaf9b"
 dependencies = [
  "indexmap",
  "toml_datetime",
@@ -3693,7 +3664,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -3846,9 +3817,9 @@ checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
 
 [[package]]
 name = "utf8-width"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1292c0d970b54115d14f2492fe0170adf21d68a1de108eebc51c1df4f346a091"
+checksum = "159a7cadce548703edd50d24069bc294c5415ecab0a480e0cd1ca06d112dc94a"
 
 [[package]]
 name = "utf8-zero"
@@ -3870,9 +3841,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.23.4"
+version = "1.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf80a72845275afea99e7f2b434723d3bc7e38470fcd1c7ed39a599c73319a53"
+checksum = "bf3923a6f5c4c6382e0b653c4117f48d631ea17f38ed86e2a828e6f7412f5239"
 dependencies = [
  "getrandom 0.4.3",
  "js-sys",
@@ -3938,15 +3909,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
-name = "wasip2"
-version = "1.0.4+wasi-0.2.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b67efb37e106e55ce722a510d6b5f9c17f083e5fc79afc2badeb12cc313d9487"
-dependencies = [
- "wit-bindgen",
-]
-
-[[package]]
 name = "wasm-bindgen"
 version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3978,7 +3940,7 @@ dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
  "wasm-bindgen-shared",
 ]
 
@@ -4003,18 +3965,18 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
-version = "1.0.8"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf85cb06032201fa7c6f829d7db5a7e5aa45bcc0655327713065f6f0576731bf"
+checksum = "7dcd9d09a39985f5344844e66b0c530a33843579125f23e21e9f0f220850f22a"
 dependencies = [
  "rustls-pki-types",
 ]
 
 [[package]]
 name = "which"
-version = "8.0.4"
+version = "8.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48d7cd18d4acb58fb3cdfe9ea54e6cd96a4e7d4cc45c56338b236e82dad47248"
+checksum = "8f3ef584124b911bcc3875c2f1472e80f24361ceb789bd1c62b3e9a3df9ff43c"
 dependencies = [
  "libc",
 ]
@@ -4049,7 +4011,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -4060,7 +4022,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -4171,18 +4133,12 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
+checksum = "23b97319f7b8343df12cc98938e5c3eb436064524c8d2b4e30a1d3a36eecdf81"
 dependencies = [
  "memchr",
 ]
-
-[[package]]
-name = "wit-bindgen"
-version = "0.57.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "writeable"
@@ -4224,28 +4180,28 @@ checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
  "synstructure",
 ]
 
 [[package]]
 name = "zerocopy"
-version = "0.8.52"
+version = "0.8.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce1022995ff5ff5d841ad7d994facc23098cd40152f2c1d11cd607c6f530653f"
+checksum = "b7cbbc0a705a0fd05cc3676525980d2bf5a9bc4adac6d6475209a7887cf59d19"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.52"
+version = "0.8.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ae7f38b72ec2a254e2b87ef277cf2cd4fb97cbebf944faa6f33354da0867930"
+checksum = "e2e817b7b52d0c7358d3246da9d69935ebb18116b2b102b4230dac079b4862f5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -4265,7 +4221,7 @@ checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
  "synstructure",
 ]
 
@@ -4283,7 +4239,7 @@ checksum = "3c50655cbb0fe3fc43170059e702f1ce5e19b84cec58dc87b037a09935c2f328"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -4316,11 +4272,11 @@ checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "zmij"
-version = "1.0.21"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+checksum = "29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "s7cmd"
 version = "1.6.0"
 edition = "2024"
-rust-version = "1.91.1"
+rust-version = "1.94.1"
 license = "Apache-2.0"
 description = "Reliable, flexible, and fast command-line tool for Amazon S3"
 authors = ["nidor1998 <nidor1998@gmail.com>"]
@@ -16,11 +16,11 @@ categories = ["command-line-utilities", "filesystem"]
 # s3sync's `lua_support` is in its default features; Lua flags
 # (--filter-callback-lua-script, etc.) automatically appear under
 # `s7cmd sync --help`. Use default-features = false to opt out.
-s3sync     = "=1.59.0"
-s3util-rs  = "=1.7.1"
+s3sync     = "=1.60.0"
+s3util-rs  = "=1.8.0"
 # Vendored bin code is sourced from these versions; pin minor.
-s3rm-rs    = "=1.3.8"
-s3ls-rs    = "=1.0.3"
+s3rm-rs    = "=1.4.0"
+s3ls-rs    = "=1.1.0"
 
 # Build-info for `s7cmd --version` (gated behind the `version` feature).
 shadow-rs = { version = "2", optional = true, default-features = false }
@@ -28,10 +28,10 @@ shadow-rs = { version = "2", optional = true, default-features = false }
 # Re-export the same AWS SDK minor versions both libs use so Cargo unifies
 # the dep tree (otherwise you get two compiled copies and possible type
 # incompatibilities at API boundaries).
-aws-sdk-s3 = { version = "1.137", default-features = false, features = ["sigv4a", "http-1x", "default-https-client", "rt-tokio"] }
-aws-config = { version = "1.8", default-features = false, features = ["behavior-version-latest", "default-https-client", "rt-tokio", "credentials-process", "sso"] }
-aws-smithy-runtime-api = "1.12"
-aws-smithy-types       = "1.5"
+aws-sdk-s3 = { version = "1.138", default-features = false, features = ["sigv4a", "http-1x", "default-https-client", "rt-tokio"] }
+aws-config = { version = "1.9", default-features = false, features = ["behavior-version-latest", "default-https-client", "rt-tokio", "credentials-process", "sso"] }
+aws-smithy-runtime-api = "1.13"
+aws-smithy-types       = "1.6"
 
 # CLI / runtime
 anyhow       = "1"
@@ -46,7 +46,7 @@ clap-verbosity-flag = "3"
 # guard. Already a transitive dep via the AWS SDK; declared directly so
 # the version is locked.
 futures      = "0.3"
-tokio        = { version = "1.52", features = ["full"] }
+tokio        = { version = "1.53", features = ["full"] }
 tracing      = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "json", "local-time"] }
 log          = "0.4"
@@ -66,7 +66,7 @@ dyn-clone    = "1.0"
 serde_json   = "1"
 # Used by the vendored get-object-annotation runner to write the downloaded
 # payload to a temp file and atomically rename it into place. Pinned to the
-# same minor s3util-rs 1.7.1 vendors so the dep tree stays unified.
+# same minor s3util-rs 1.8.0 vendors so the dep tree stays unified.
 tempfile     = "3"
 
 [features]
@@ -83,7 +83,7 @@ uuid = { version = "1", features = ["v4"] }
 # tempfile is a regular dependency (see [dependencies]); it is therefore also
 # available to tests without a separate dev-dependency entry.
 # Used by the vendored get_object_annotation.rs unit tests to recompute the
-# MD5 an AES256 object's ETag encodes. Same minor s3util-rs 1.7.1 vendors.
+# MD5 an AES256 object's ETag encodes. Same minor s3util-rs 1.8.0 vendors.
 md5 = "0.8"
 # Used by mv.rs unit tests to implement a fake `StorageTrait` for the
 # source-delete decision tree. Already a transitive dep via s3util-rs;

--- a/README.md
+++ b/README.md
@@ -220,7 +220,7 @@ freely combined:
 | (default) | Read the whole script first, validate every line, then execute. Catches bad lines before any line runs. Shows a progress bar when stderr is a TTY. |
 | `--streaming` | Execute commands as they are read. No progress bar. Use for unbounded or pipelined input where buffering the whole script is undesirable. |
 | `--parallel 1` (default) | Sequential execution. Lines run in script order. |
-| `--parallel N` | Run up to *N* commands concurrently. Completion order is not guaranteed. |
+| `--parallel N` | Run up to *N* commands concurrently (max 1024; a larger value is rejected at parse time). Completion order is not guaranteed. |
 | `--parallel 0` | Use all logical CPUs. Completion order is not guaranteed. |
 
 Script order is preserved only with `--parallel 1`. With
@@ -274,7 +274,11 @@ and a matching outcome event (`success`, `warning (exit N)`,
 line number and the original input text. `start` and `success`
 are info level (silent at the default warn level — pass `-v` to
 see them); `warning` and `skipped` are warn level and `failure`
-is error level, all three visible without `-v`.
+is error level, all three visible without `-v`. If a line carries
+an inline credential option (`--*-access-key`,
+`--*-secret-access-key`, `--*-session-token`, `--*-sse-c-key`,
+`--*-sse-c-key-md5`), its value is masked to `****` in the logged
+text.
 
 **Tracing flags belong to `batch-run`, not per-line.** Pass
 `--json-tracing`, `--aws-sdk-tracing`, `--span-events-tracing`,

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -489,12 +489,12 @@ fn build_cli_command() -> clap::Command {
 /// current value of an arg's env var into help text by default; the env var
 /// *name* stays visible, only the value is suppressed.
 ///
-/// Upstream fixes this at the derive level — s3sync PR#246, s3rm-rs PR#94,
-/// s3ls-rs PR#29, and s3util-rs PR#25 all add `hide_env_values = true` to
-/// their credential args — but those changes are not yet in the released
-/// crates s7cmd pins, so the same hardening is applied here to the built
-/// `Command` tree. Once the upstream releases catch up this becomes an
-/// idempotent no-op.
+/// Upstream fixes this at the derive level: s3sync 1.60.0, s3rm-rs 1.4.0,
+/// s3ls-rs 1.1.0, and s3util-rs 1.8.0 (the releases s7cmd pins) all mark
+/// their credential args `hide_env_values = true`, so this pass is an
+/// idempotent no-op today. It is kept as a guard: a future upstream release
+/// that adds a credential arg without the marking (or drops it) is re-hidden
+/// here rather than leaking secrets into `--help` output.
 ///
 /// The id predicate matches the exact set upstream hides: access keys,
 /// secret access keys, session tokens (`*access_key*`, `*session_token*`)
@@ -627,10 +627,11 @@ mod tests {
     /// Every env-backed credential argument across every subcommand must be
     /// `hide_env_values` so `--help` never echoes a secret exported through
     /// the environment. Mirrors the upstream guard test added by s3util-rs
-    /// PR#25; here the invariant is enforced by `hide_credential_env_values`
-    /// because the released upstream crates do not yet carry their own
-    /// `hide_env_values = true` fixes (s3sync PR#246, s3rm-rs PR#94,
-    /// s3ls-rs PR#29, s3util-rs PR#25).
+    /// PR#25. The pinned upstream releases (s3sync 1.60.0, s3rm-rs 1.4.0,
+    /// s3ls-rs 1.1.0, s3util-rs 1.8.0) now carry their own
+    /// `hide_env_values = true` markings; `hide_credential_env_values` backs
+    /// them up so a future upstream credential arg that misses the marking
+    /// still cannot leak.
     #[test]
     fn credential_args_hide_env_values_in_every_subcommand() {
         fn check(cmd: &clap::Command, path: &str, checked: &mut usize) {

--- a/src/util_bin/cli/cp.rs
+++ b/src/util_bin/cli/cp.rs
@@ -62,6 +62,7 @@ async fn target_exists(config: &Config) -> anyhow::Result<bool> {
                 sse_c_key: config.target_sse_c_key.key.clone(),
                 sse_c_key_md5: config.target_sse_c_key_md5.clone(),
                 enable_additional_checksum: false,
+                request_payer: target_client_config.request_payer.clone(),
             };
             match api::head_object(&client, bucket, &target_key, opts).await {
                 Ok(_) => Ok(true),

--- a/src/util_bin/cli/get_object_tagging.rs
+++ b/src/util_bin/cli/get_object_tagging.rs
@@ -27,7 +27,15 @@ pub async fn run_get_object_tagging(
 
     let client = client_config.create_client().await;
 
-    match api::get_object_tagging(&client, &bucket, &key, args.source_version_id.as_deref()).await {
+    match api::get_object_tagging(
+        &client,
+        &bucket,
+        &key,
+        args.source_version_id.as_deref(),
+        client_config.request_payer.clone(),
+    )
+    .await
+    {
         Ok(out) => {
             let json = get_object_tagging_to_json(&out);
             let pretty = serde_json::to_string_pretty(&json)?;

--- a/src/util_bin/cli/head_object.rs
+++ b/src/util_bin/cli/head_object.rs
@@ -38,6 +38,7 @@ pub async fn run_head_object(
         sse_c_key: args.source_sse_c_key.clone(),
         sse_c_key_md5: args.source_sse_c_key_md5.clone(),
         enable_additional_checksum: args.enable_additional_checksum,
+        request_payer: client_config.request_payer.clone(),
     };
 
     match api::head_object(&client, &bucket, &key, opts).await {

--- a/src/util_bin/cli/indicator.rs
+++ b/src/util_bin/cli/indicator.rs
@@ -361,8 +361,8 @@ mod tests {
         join_handle.await.unwrap();
     }
 
-    // Ported from s3util-rs PR#25 (post-1.7.1), adapted to the vendored
-    // 7-parameter show_indicator signature.
+    // Ported from s3util-rs 1.8.0 (originally PR#25), adapted to the
+    // vendored 7-parameter show_indicator signature.
     #[tokio::test]
     async fn indicator_counts_mismatches_as_warnings() {
         // ETagMismatch / ChecksumMismatch must bump both their own counter and

--- a/src/util_bin/cli/mod.rs
+++ b/src/util_bin/cli/mod.rs
@@ -3,12 +3,11 @@
 // Adjustments: stripped #[cfg(test)] mod tests; commented out per-subcommand
 //              pub mod declarations (re-enabled per task as files land);
 //              kept ExitStatus, EXIT_CODE_*, run_copy_phase, build_rate_limiter.
-// Includes fixes ported from s3util-rs PR#25 (post-1.7.1):
+// Includes fixes from s3util-rs 1.8.0 (originally PR#25):
 //   - is_user_cancellation: a worker failure that cancels the pipeline token
 //     is reported as a failure (exit 1), not a SIGINT cancellation (exit 130);
 //   - extract_keys: a local target with a trailing '/' resolves to
-//     <dir>/<basename> on every platform (adapted to 1.7.1's
-//     fs_util::is_key_a_directory — has_trailing_separator lands later).
+//     <dir>/<basename> on every platform (fs_util::has_trailing_separator).
 
 use std::sync::Arc;
 use std::sync::atomic::AtomicBool;
@@ -666,10 +665,8 @@ pub(super) fn extract_keys(config: &Config) -> Result<(String, String)> {
             // The separator test must accept '/' on Windows too, so that `out/`
             // resolves to `out/<basename>` rather than staying the literal key
             // `out/`, which the storage layer would treat as a directory and
-            // silently write nothing for. (Upstream calls
-            // fs_util::has_trailing_separator, introduced after 1.7.1;
-            // is_key_a_directory is the same trailing-separator test.)
-            if p.is_dir() || fs_util::is_key_a_directory(&p.to_string_lossy()) {
+            // silently write nothing for.
+            if p.is_dir() || fs_util::has_trailing_separator(&p.to_string_lossy()) {
                 p.join(&source_basename).to_string_lossy().to_string()
             } else {
                 p.to_string_lossy().to_string()

--- a/src/util_bin/cli/mv.rs
+++ b/src/util_bin/cli/mv.rs
@@ -1,7 +1,7 @@
 // Vendored from s3util-rs@1.1.0
 //   src/bin/s3util/cli/mv.rs
 // Adjustments: stripped #[cfg(test)] mod tests; rewrote crate::cli → super
-// Includes the self-move guard ported from s3util-rs PR#25 (post-1.7.1):
+// Includes the self-move guard from s3util-rs 1.8.0 (originally PR#25):
 //   check_not_self_move rejects `mv` onto the same S3 object before the copy
 //   runs (copy-then-delete would destroy the object on an unversioned bucket).
 

--- a/src/util_bin/cli/presign.rs
+++ b/src/util_bin/cli/presign.rs
@@ -24,8 +24,14 @@ pub async fn run_presign(args: PresignArgs, client_config: ClientConfig) -> Resu
         .map_err(|e| anyhow::anyhow!("{}", e.trim_end()))?;
 
     let client = client_config.create_client().await;
-    let url = api::presign_get_object(&client, &bucket, &key, Duration::from_secs(args.expires_in))
-        .await?;
+    let url = api::presign_get_object(
+        &client,
+        &bucket,
+        &key,
+        Duration::from_secs(args.expires_in),
+        client_config.request_payer.clone(),
+    )
+    .await?;
     println!("{url}");
     Ok(ExitStatus::Success)
 }

--- a/src/util_bin/cli/put_bucket_lifecycle_configuration.rs
+++ b/src/util_bin/cli/put_bucket_lifecycle_configuration.rs
@@ -1,16 +1,15 @@
-// Vendored from s3util-rs@1.1.0
+// Vendored from s3util-rs@1.8.0
 //   src/bin/s3util/cli/put_bucket_lifecycle_configuration.rs
 // Adjustments: no tests stripped; rewrote crate::cli → super
-// Includes an adapted fix from s3util-rs PR#25 (post-1.7.1): a top-level
-// `TransitionDefaultMinimumObjectSize` in the input JSON is rejected with
-// guidance instead of being silently dropped. Upstream implements this via
-// `deny_unknown_fields` on the input structs plus a
-// `--transition-default-minimum-object-size` flag; neither exists in the
-// released 1.7.1 library, so the vendored runner checks the raw JSON itself
-// (the flag pointer in the upstream hint is omitted until the library ships).
+// The 1.8.0 library rejects unknown JSON fields (`deny_unknown_fields`), so a
+// top-level `TransitionDefaultMinimumObjectSize` — as produced by
+// `get-bucket-lifecycle-configuration` — fails the parse; the runner maps that
+// error to a hint pointing at `--transition-default-minimum-object-size`,
+// which sends the value as the request parameter S3 actually accepts.
 use anyhow::{Context, Result};
 use tracing::info;
 
+use aws_sdk_s3::types::TransitionDefaultMinimumObjectSize;
 use s3util_rs::config::ClientConfig;
 use s3util_rs::config::args::put_bucket_lifecycle_configuration::PutBucketLifecycleConfigurationArgs;
 use s3util_rs::input::json::LifecycleConfigurationJson;
@@ -54,7 +53,17 @@ pub async fn run_put_bucket_lifecycle_configuration(
         info!(bucket = %bucket, "[dry-run] would put bucket lifecycle configuration.");
         return Ok(());
     }
-    api::put_bucket_lifecycle_configuration(&client, &bucket, cfg).await?;
+    let transition_default_minimum_object_size = args
+        .transition_default_minimum_object_size
+        .as_deref()
+        .map(TransitionDefaultMinimumObjectSize::from);
+    api::put_bucket_lifecycle_configuration(
+        &client,
+        &bucket,
+        cfg,
+        transition_default_minimum_object_size,
+    )
+    .await?;
     info!(bucket = %bucket, "Bucket lifecycle configuration set.");
     Ok(())
 }
@@ -64,23 +73,23 @@ pub async fn run_put_bucket_lifecycle_configuration(
 /// `get-bucket-lifecycle-configuration` reports `TransitionDefaultMinimumObjectSize`
 /// at the top level (matching `aws s3api`), but S3 accepts it only as a request
 /// parameter, never inside the configuration document — so feeding the get
-/// output back into put must not carry it along. The 1.7.1 library's
-/// `LifecycleConfigurationJson` silently ignores unknown fields, which would
-/// drop the value and reset the bucket to S3's default of
-/// `all_storage_classes_128K`. Reject it up front instead.
+/// output back into put is rejected by `deny_unknown_fields`. That rejection is
+/// correct (silently dropping it would reset the bucket to S3's default), but
+/// the bare serde error is a dead end; point at the flag that sends it.
 fn parse_lifecycle_configuration(body: &str) -> Result<LifecycleConfigurationJson> {
-    let value: serde_json::Value = serde_json::from_str(body)?;
-    if value
-        .as_object()
-        .is_some_and(|o| o.contains_key("TransitionDefaultMinimumObjectSize"))
-    {
-        anyhow::bail!(
-            "`TransitionDefaultMinimumObjectSize` is a request parameter, not part of the \
-             lifecycle configuration document: remove it from the JSON (S3 then applies its \
-             default of `all_storage_classes_128K`)"
-        );
-    }
-    serde_json::from_value(value).map_err(anyhow::Error::from)
+    serde_json::from_str(body).map_err(|e| {
+        if e.to_string()
+            .contains("unknown field `TransitionDefaultMinimumObjectSize`")
+        {
+            anyhow::anyhow!(e).context(
+                "`TransitionDefaultMinimumObjectSize` is a request parameter, not part of the \
+                 lifecycle configuration document: remove it from the JSON and pass it with \
+                 --transition-default-minimum-object-size instead",
+            )
+        } else {
+            anyhow::anyhow!(e)
+        }
+    })
 }
 
 #[cfg(test)]
@@ -96,31 +105,30 @@ mod tests {
 
     /// Feeding `get-bucket-lifecycle-configuration` output (which carries
     /// `TransitionDefaultMinimumObjectSize` at the top level) into put must
-    /// fail with guidance, not silently drop the value — dropping it would
-    /// reset a bucket set to `varies_by_storage_class` back to S3's default.
+    /// fail with a hint at the flag, not a bare unknown-field error.
     #[test]
-    fn get_output_fed_back_into_put_is_rejected_with_guidance() {
+    fn get_output_fed_back_into_put_hints_at_the_flag() {
         let body = r#"{"Rules": [{"ID": "r1", "Status": "Enabled",
             "Expiration": {"Days": 30}, "Filter": {"Prefix": ""}}],
             "TransitionDefaultMinimumObjectSize": "all_storage_classes_128K"}"#;
         let err = parse_lifecycle_configuration(body).unwrap_err();
         assert!(
-            format!("{err:#}").contains("request parameter"),
-            "error must explain the field is a request parameter; got: {err:#}"
+            format!("{err:#}").contains("--transition-default-minimum-object-size"),
+            "error must point at the flag; got: {err:#}"
         );
     }
 
-    /// Other unknown fields keep the 1.7.1 library behavior (ignored by
-    /// serde), without the unrelated guidance firing.
+    /// Any other unknown field keeps the plain serde error, without the
+    /// unrelated hint.
     #[test]
-    fn other_unknown_fields_do_not_trigger_the_guidance() {
+    fn other_unknown_fields_do_not_get_the_hint() {
         let body = r#"{"Rules": [], "Bogus": 1}"#;
-        let result = parse_lifecycle_configuration(body);
+        let err = parse_lifecycle_configuration(body).unwrap_err();
+        let msg = format!("{err:#}");
+        assert!(msg.contains("unknown field `Bogus`"), "got: {msg}");
         assert!(
-            result.is_ok(),
-            "unknown fields other than TransitionDefaultMinimumObjectSize keep \
-             the 1.7.1 ignore behavior; got: {:?}",
-            result.err()
+            !msg.contains("--transition-default-minimum-object-size"),
+            "hint must only fire for TransitionDefaultMinimumObjectSize; got: {msg}"
         );
     }
 

--- a/src/util_bin/cli/put_object_tagging.rs
+++ b/src/util_bin/cli/put_object_tagging.rs
@@ -46,6 +46,7 @@ pub async fn run_put_object_tagging(
         &key,
         args.source_version_id.as_deref(),
         tagging,
+        client_config.request_payer.clone(),
     )
     .await?;
     info!(

--- a/src/util_bin/cli/restore_object.rs
+++ b/src/util_bin/cli/restore_object.rs
@@ -57,6 +57,7 @@ pub async fn run_restore_object(
         &key,
         args.source_version_id.as_deref(),
         restore_request,
+        client_config.request_payer.clone(),
     )
     .await
     {

--- a/src/util_bin/cli/rm.rs
+++ b/src/util_bin/cli/rm.rs
@@ -30,7 +30,14 @@ pub async fn run_rm(args: RmArgs, client_config: ClientConfig) -> Result<()> {
         return Ok(());
     }
 
-    api::delete_object(&client, &bucket, &key, args.source_version_id.as_deref()).await?;
+    api::delete_object(
+        &client,
+        &bucket,
+        &key,
+        args.source_version_id.as_deref(),
+        client_config.request_payer.clone(),
+    )
+    .await?;
     info!(
         bucket = %bucket,
         key = %key,

--- a/src/util_bin/tracing_init.rs
+++ b/src/util_bin/tracing_init.rs
@@ -274,7 +274,7 @@ mod tests {
     /// Drive the real `PipeSafeWriter` through its non-BrokenPipe arms. The
     /// BrokenPipe arms need stderr to be an actually-closed pipe and are
     /// exercised at process level by the e2e suites. Ported from s3util-rs
-    /// PR#25 (post-1.7.1).
+    /// 1.8.0 (originally PR#25).
     #[test]
     fn pipe_safe_writer_write_and_flush_pass_through() {
         use std::io::Write;

--- a/tests/e2e_exit_codes.rs
+++ b/tests/e2e_exit_codes.rs
@@ -147,7 +147,7 @@ async fn auto_complete_shell_emits_script_and_exits_zero() {
     assert!(
         stdout.contains("s7cmd"),
         "expected bash completion output mentioning 's7cmd', got first 200 chars: {}",
-        &stdout.chars().take(200).collect::<String>()
+        stdout.chars().take(200).collect::<String>()
     );
 }
 
@@ -174,7 +174,7 @@ async fn auto_complete_shell_zsh() {
     assert!(
         stdout.contains("#compdef s7cmd"),
         "expected zsh completion output containing '#compdef s7cmd', got first 200 chars: {}",
-        &stdout.chars().take(200).collect::<String>()
+        stdout.chars().take(200).collect::<String>()
     );
 }
 
@@ -201,7 +201,7 @@ async fn auto_complete_shell_fish() {
     assert!(
         stdout.contains("complete -c s7cmd"),
         "expected fish completion output containing 'complete -c s7cmd', got first 200 chars: {}",
-        &stdout.chars().take(200).collect::<String>()
+        stdout.chars().take(200).collect::<String>()
     );
 }
 


### PR DESCRIPTION
…s3ls-rs 1.1.0

Monthly upstream releases (2026-07-20). Reconciles the vendored bin runners with the released s3util-rs 1.8.0 API:

- wire request_payer through rm, head-object, get-object-tagging, put-object-tagging, restore-object, presign, and the cp --skip-existing probe (--target-request-payer was parsed and discarded; the updated api::* signatures now require it)
- put-bucket-lifecycle-configuration: adopt the released deny_unknown_fields behavior and wire the new --transition-default-minimum-object-size flag into the request
- extract_keys: use fs_util::has_trailing_separator (public in 1.8.0)
- MSRV 1.91.1 -> 1.94.1; sync AWS SDK re-export minors (aws-sdk-s3 1.138, aws-config 1.9, smithy-runtime-api 1.13, smithy-types 1.6) and tokio 1.53
- note the upstream catch-up in the hide_env_values overlay comments; fix three clippy-1.97 warnings in tests/e2e_exit_codes.rs

cargo fmt / clippy (both cfgs) clean; 1180 tests pass; cargo deny ok.

## Contributing

- Bug reports are welcome, but responses are not guaranteed.
- Since this project is considered functionally complete, I will not accept any feature requests.
- If you find this project useful, feel free to fork and modify it as you wish.

🔒 I consider this project “complete” and will maintain it only minimally going forward.
However, I intend to keep the AWS SDK for Rust and other dependencies up to date monthly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for `--transition-default-minimum-object-size` when configuring bucket lifecycle rules.
  - Request-payer settings are now honored across additional object operations, including checks, tagging, restore, deletion, and presigned downloads.
  - Improved directory-target handling across platforms.

- **Security**
  - Credentials supplied to `batch-run` command lines are masked before appearing in logs.

- **Bug Fixes**
  - Lifecycle configuration errors now provide clearer guidance when unsupported fields require the new option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->