### PR TITLE
feat(deps): update to s3sync 1.61.0, s3util-rs 1.9.0, s3rm-rs 1.5.0, …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,18 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.7.0] - 2026-07-25
 
-Monthly update.
-
-Bug-fix release. The pinned libraries are updated to their 2026-07-25 releases — s3sync `v1.61.0`, s3util-rs `v1.9.0`,
-s3rm-rs `v1.5.0`, s3ls-rs `v1.2.0` — which all carry the same fix: positional arguments no longer read values from
-environment variables (see **Fixed** below). No s7cmd-side code changes were required beyond the dependency bump;
-regression tests pin the new behavior.
+Bug-fix release. 
 
 ### Fixed
 
 #### All subcommands
 
-- Exported `SOURCE` / `TARGET` environment variables no longer silently supply positional arguments. The underlying
+- [Breaking change] Exported `SOURCE` / `TARGET` environment variables no longer silently supply positional arguments. The underlying
   libraries declared every positional source/target argument with clap's `env` attribute, so an unrelated exported
   variable named after a positional was parsed as if it had been passed on the command line: `TARGET=s3://bucket
   s7cmd clean` proceeded toward a real deletion pipeline against the env-named bucket, `SOURCE`/`TARGET` satisfied
@@ -28,11 +23,21 @@ regression tests pin the new behavior.
   come only from the command line. Explicitly passed positionals were never affected (command-line values always took
   precedence).
 
-### Changed
+#### s3util-rs
 
-- Updated pinned engine libraries: s3sync `1.60.0` → `1.61.0`, s3util-rs `1.8.0` → `1.9.0`, s3rm-rs `1.4.0` →
-  `1.5.0`, s3ls-rs `1.1.0` → `1.2.0`. Aside from the positional env-var fix above, the releases are otherwise
-  identical to the previously pinned versions; the vendored CLI frontends required no reconciliation.
+- `put-bucket-lifecycle-configuration` now accepts lifecycle `Date` values carrying an ISO 8601 numeric UTC offset
+  (e.g. `2030-01-02T03:04:05+00:00`) in addition to `Z`; a non-zero offset is converted to UTC.
+  `get-bucket-lifecycle-configuration` emits dates with `+00:00`, so feeding its output back into
+  `put-bucket-lifecycle-configuration` failed with `invalid ISO 8601 timestamp` for any date-based rule.
+
+### Underlying libraries
+
+```toml
+s3sync = "=1.61.0"
+s3util-rs = "=1.9.0"
+s3rm-rs = "=1.5.0"
+s3ls-rs = "=1.2.0"
+```
 
 ## [1.6.0] - 2026-07-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,35 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.7.0] - 2026-07-25
+
+Monthly update.
+
+Bug-fix release. The pinned libraries are updated to their 2026-07-25 releases — s3sync `v1.61.0`, s3util-rs `v1.9.0`,
+s3rm-rs `v1.5.0`, s3ls-rs `v1.2.0` — which all carry the same fix: positional arguments no longer read values from
+environment variables (see **Fixed** below). No s7cmd-side code changes were required beyond the dependency bump;
+regression tests pin the new behavior.
+
+### Fixed
+
+#### All subcommands
+
+- Exported `SOURCE` / `TARGET` environment variables no longer silently supply positional arguments. The underlying
+  libraries declared every positional source/target argument with clap's `env` attribute, so an unrelated exported
+  variable named after a positional was parsed as if it had been passed on the command line: `TARGET=s3://bucket
+  s7cmd clean` proceeded toward a real deletion pipeline against the env-named bucket, `SOURCE`/`TARGET` satisfied
+  `sync` and `cp` paths, an exported `TARGET` satisfied every util subcommand's otherwise-required target (e.g.
+  `head-bucket`, `get-bucket-versioning`), and `ls` listed the env-named target instead of falling back to
+  bucket-listing mode. The updated libraries drop the `env` attribute from every positional argument; positionals now
+  come only from the command line. Explicitly passed positionals were never affected (command-line values always took
+  precedence).
+
+### Changed
+
+- Updated pinned engine libraries: s3sync `1.60.0` → `1.61.0`, s3util-rs `1.8.0` → `1.9.0`, s3rm-rs `1.4.0` →
+  `1.5.0`, s3ls-rs `1.1.0` → `1.2.0`. Aside from the positional env-var fix above, the releases are otherwise
+  identical to the previously pinned versions; the vendored CLI frontends required no reconciliation.
+
 ## [1.6.0] - 2026-07-20
 
 Monthly update.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2843,9 +2843,9 @@ checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "s3ls-rs"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1734e45cddb7916945f830441779d9a980dc27ccdaa8a388d9898bade1d01fcd"
+checksum = "1b47be291c58d89c7647352a9aba480ec1117bcd439d50e7cef912de1e6e086c"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2879,9 +2879,9 @@ dependencies = [
 
 [[package]]
 name = "s3rm-rs"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89fed70cc0f10da6541d03fe6f1c0146c97abdbaa4f2eb557c89a3dd27d025cf"
+checksum = "32d127b7552d7908708e5475b85dd8a73189211d603d20a32a265686fc14de50"
 dependencies = [
  "anyhow",
  "async-channel",
@@ -2921,9 +2921,9 @@ dependencies = [
 
 [[package]]
 name = "s3sync"
-version = "1.60.0"
+version = "1.61.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1653378798b45cbf555361b287b226d120ddc97f8d5390108fbf5699d7ec14d0"
+checksum = "db4b2d5cac3398e17b4a731af28082254400c72b7d197a1a2510bfac7e9bb291"
 dependencies = [
  "anyhow",
  "async-channel",
@@ -2983,9 +2983,9 @@ dependencies = [
 
 [[package]]
 name = "s3util-rs"
-version = "1.8.0"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99116d2992cdbaa894f23e66b2e1d082beb63d12d4cefb0b94b1cb6d83ef4468"
+checksum = "31386e4947da79fc9b7e25f53ae3f8d1a0f0b8f35dd0e3349332d20c6a0fbb8a"
 dependencies = [
  "anyhow",
  "async-channel",
@@ -3042,7 +3042,7 @@ dependencies = [
 
 [[package]]
 name = "s7cmd"
-version = "1.6.0"
+version = "1.7.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "s7cmd"
-version = "1.6.0"
+version = "1.7.0"
 edition = "2024"
 rust-version = "1.94.1"
 license = "Apache-2.0"
@@ -16,11 +16,11 @@ categories = ["command-line-utilities", "filesystem"]
 # s3sync's `lua_support` is in its default features; Lua flags
 # (--filter-callback-lua-script, etc.) automatically appear under
 # `s7cmd sync --help`. Use default-features = false to opt out.
-s3sync     = "=1.60.0"
-s3util-rs  = "=1.8.0"
+s3sync     = "=1.61.0"
+s3util-rs  = "=1.9.0"
 # Vendored bin code is sourced from these versions; pin minor.
-s3rm-rs    = "=1.4.0"
-s3ls-rs    = "=1.1.0"
+s3rm-rs    = "=1.5.0"
+s3ls-rs    = "=1.2.0"
 
 # Build-info for `s7cmd --version` (gated behind the `version` feature).
 shadow-rs = { version = "2", optional = true, default-features = false }
@@ -66,7 +66,7 @@ dyn-clone    = "1.0"
 serde_json   = "1"
 # Used by the vendored get-object-annotation runner to write the downloaded
 # payload to a temp file and atomically rename it into place. Pinned to the
-# same minor s3util-rs 1.8.0 vendors so the dep tree stays unified.
+# same minor s3util-rs 1.9.0 vendors so the dep tree stays unified.
 tempfile     = "3"
 
 [features]
@@ -83,7 +83,7 @@ uuid = { version = "1", features = ["v4"] }
 # tempfile is a regular dependency (see [dependencies]); it is therefore also
 # available to tests without a separate dev-dependency entry.
 # Used by the vendored get_object_annotation.rs unit tests to recompute the
-# MD5 an AES256 object's ETag encodes. Same minor s3util-rs 1.8.0 vendors.
+# MD5 an AES256 object's ETag encodes. Same minor s3util-rs 1.9.0 vendors.
 md5 = "0.8"
 # Used by mv.rs unit tests to implement a fake `StorageTrait` for the
 # source-delete decision tree. Already a transitive dep via s3util-rs;

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -489,8 +489,8 @@ fn build_cli_command() -> clap::Command {
 /// current value of an arg's env var into help text by default; the env var
 /// *name* stays visible, only the value is suppressed.
 ///
-/// Upstream fixes this at the derive level: s3sync 1.60.0, s3rm-rs 1.4.0,
-/// s3ls-rs 1.1.0, and s3util-rs 1.8.0 (the releases s7cmd pins) all mark
+/// Upstream fixes this at the derive level: s3sync 1.61.0, s3rm-rs 1.5.0,
+/// s3ls-rs 1.2.0, and s3util-rs 1.9.0 (the releases s7cmd pins) all mark
 /// their credential args `hide_env_values = true`, so this pass is an
 /// idempotent no-op today. It is kept as a guard: a future upstream release
 /// that adds a credential arg without the marking (or drops it) is re-hidden
@@ -627,8 +627,8 @@ mod tests {
     /// Every env-backed credential argument across every subcommand must be
     /// `hide_env_values` so `--help` never echoes a secret exported through
     /// the environment. Mirrors the upstream guard test added by s3util-rs
-    /// PR#25. The pinned upstream releases (s3sync 1.60.0, s3rm-rs 1.4.0,
-    /// s3ls-rs 1.1.0, s3util-rs 1.8.0) now carry their own
+    /// PR#25. The pinned upstream releases (s3sync 1.61.0, s3rm-rs 1.5.0,
+    /// s3ls-rs 1.2.0, s3util-rs 1.9.0) now carry their own
     /// `hide_env_values = true` markings; `hide_credential_env_values` backs
     /// them up so a future upstream credential arg that misses the marking
     /// still cannot leak.

--- a/tests/cli_arg_validation.rs
+++ b/tests/cli_arg_validation.rs
@@ -691,6 +691,99 @@ fn auto_complete_shell_env_does_not_lift_cp_paths() {
     );
 }
 
+// ---- SOURCE / TARGET env vars must not populate positionals ----
+//
+// Through s3sync 1.60.0 / s3util-rs 1.8.0 / s3rm-rs 1.4.0 / s3ls-rs 1.1.0 the
+// positional source/target args carried clap's `env` attribute, so exported
+// SOURCE / TARGET variables silently supplied them: `TARGET=s3://b s7cmd
+// clean` deleted from the env-named bucket, and an unrelated exported TARGET
+// satisfied every util subcommand's required target. The pinned 1.61.0 /
+// 1.9.0 / 1.5.0 / 1.2.0 releases drop `env` from every positional; these
+// tests pin that behavior against an upstream regression.
+
+#[test]
+fn source_target_env_do_not_supply_sync_paths() {
+    let (code, _stdout, stderr) = run(s7cmd_cmd()
+        .arg("sync")
+        .env("SOURCE", "s3://env-source-bucket")
+        .env("TARGET", "s3://env-target-bucket"));
+    assert_eq!(
+        code,
+        Some(2),
+        "sync must still require positional source/target with SOURCE/TARGET exported; stderr={stderr}"
+    );
+    assert!(
+        stderr.to_lowercase().contains("source"),
+        "expected missing source error; got: {stderr}"
+    );
+}
+
+#[test]
+fn target_env_does_not_supply_clean_target() {
+    // The most dangerous variant: before the fix, `clean` with no positional
+    // proceeded toward a real deletion pipeline against the env-named bucket.
+    let (code, _stdout, stderr) = run(s7cmd_cmd()
+        .arg("clean")
+        .env("TARGET", "s3://env-target-bucket"));
+    assert_eq!(
+        code,
+        Some(2),
+        "clean must still require a positional target with TARGET exported; stderr={stderr}"
+    );
+    assert!(
+        stderr.to_lowercase().contains("required"),
+        "expected missing target error; got: {stderr}"
+    );
+}
+
+#[test]
+fn source_target_env_do_not_supply_cp_paths() {
+    let (code, _stdout, stderr) = run(s7cmd_cmd()
+        .arg("cp")
+        .env("SOURCE", "s3://env-source-bucket")
+        .env("TARGET", "s3://env-target-bucket"));
+    assert_eq!(
+        code,
+        Some(2),
+        "cp must still require positional source/target with SOURCE/TARGET exported; stderr={stderr}"
+    );
+    assert!(
+        stderr.to_lowercase().contains("required"),
+        "expected missing source/target error; got: {stderr}"
+    );
+}
+
+#[test]
+fn target_env_does_not_supply_util_target() {
+    let (code, _stdout, stderr) = run(s7cmd_cmd()
+        .arg("get-bucket-versioning")
+        .env("TARGET", "s3://env-target-bucket"));
+    assert_eq!(
+        code,
+        Some(2),
+        "TARGET env var must not satisfy the required target; stderr={stderr}"
+    );
+    assert!(
+        stderr.to_lowercase().contains("required"),
+        "expected missing-required parse error; got: {stderr}"
+    );
+}
+
+#[test]
+fn target_env_invalid_value_is_not_parsed() {
+    // If the env source were still wired, clap would run the value parser on
+    // the env value and fail with an invalid-value error; the fix means the
+    // variable is never even read.
+    let (code, _stdout, stderr) = run(s7cmd_cmd()
+        .arg("get-bucket-versioning")
+        .env("TARGET", "notavalidpath"));
+    assert_eq!(code, Some(2));
+    assert!(
+        stderr.to_lowercase().contains("required") && !stderr.contains("invalid value"),
+        "env value must be ignored entirely, not parsed; got: {stderr}"
+    );
+}
+
 // ---- batch-run --parallel upper bound ----
 //
 // `--parallel` is capped at MAX_PARALLEL (1024). An oversized or overflowing

--- a/tests/cli_ls.rs
+++ b/tests/cli_ls.rs
@@ -1,16 +1,18 @@
-//! Process-level CLI tests for the `ls` subcommand's broken-pipe handling.
-//! These run without AWS credentials or network access (they talk only to a
-//! loopback mock endpoint).
+//! Process-level CLI tests for the `ls` subcommand: broken-pipe handling and
+//! env-var isolation of the positional target. These run without AWS
+//! credentials or network access (they talk only to a loopback mock
+//! endpoint).
 //!
 //! `s7cmd ls | head -1`-style consumers close the pipe early; `ls` must treat
 //! the resulting `BrokenPipe` write error as a silent success (exit 0), in
 //! both bucket-listing mode (no target) and listing-pipeline mode (target
-//! prefix). Each test delays the mock response, closes the child's stdout
-//! immediately after spawn, and only then lets the listing arrive — so the
-//! child's first stdout flush hits a closed pipe deterministically.
+//! prefix). Each broken-pipe test delays the mock response, closes the
+//! child's stdout immediately after spawn, and only then lets the listing
+//! arrive — so the child's first stdout flush hits a closed pipe
+//! deterministically.
 
 mod common;
-use common::{MockResponse, MockS3Server, mock_target_args, s7cmd_cmd_clean_env};
+use common::{MockResponse, MockS3Server, mock_target_args, run, s7cmd_cmd_clean_env};
 
 use std::time::Duration;
 
@@ -64,6 +66,30 @@ fn bucket_listing_broken_pipe_exits_0() {
         code,
         Some(0),
         "BrokenPipe in bucket-listing mode must exit 0; stderr: {stderr}"
+    );
+}
+
+/// A `TARGET` env var must not supply `ls`'s optional positional. Through
+/// s3ls-rs 1.1.0 the positional carried clap's `env` attribute, so an
+/// exported TARGET was parsed as the listing target (an invalid value even
+/// failed the run at clap parse time); s3ls-rs 1.2.0 drops `env`. With the
+/// variable exported, `ls` must ignore it and fall back to bucket-listing
+/// mode against the mock endpoint.
+#[test]
+fn target_env_does_not_supply_ls_target() {
+    let server = MockS3Server::start(vec![MockResponse::new(200, LIST_BUCKETS_XML)]);
+    let (code, stdout, stderr) = run(s7cmd_cmd_clean_env()
+        .arg("ls")
+        .args(mock_target_args(&server.endpoint_url()))
+        .env("TARGET", "notavalidpath"));
+    assert_eq!(
+        code,
+        Some(0),
+        "TARGET env var must be ignored (bucket-listing mode); stderr: {stderr}"
+    );
+    assert!(
+        stdout.contains("mock-bucket-1"),
+        "expected bucket listing on stdout; got: {stdout}"
     );
 }
 


### PR DESCRIPTION
…s3ls-rs 1.2.0

Monthly upstream releases (2026-07-25). All four carry the same fix: clap's `env` attribute is dropped from every positional source/target argument, so exported SOURCE / TARGET environment variables no longer silently supply positionals (`TARGET=s3://bucket s7cmd clean` headed toward a real deletion pipeline against the env-named bucket; an exported TARGET satisfied every util subcommand's required target and redirected `ls` away from bucket-listing mode).

- upstream src/bin is byte-identical between the old and new releases, so the vendored frontends required no reconciliation; the AWS SDK re-export minors are unchanged
- refresh the pinned-release citations in Cargo.toml and cli.rs comments
- add regression tests pinning the fixed behavior: sync/clean/cp and get-bucket-versioning must still fail parse (exit 2) with SOURCE/TARGET exported, an invalid TARGET env value must never be parsed, and `ls` must ignore TARGET and list buckets (mock endpoint)
- bump s7cmd to 1.7.0; CHANGELOG entry dated 2026-07-25

cargo fmt / clippy (both cfgs) clean; offline suite passes; cargo deny ok.

## Contributing

- Bug reports are welcome, but responses are not guaranteed.
- Since this project is considered functionally complete, I will not accept any feature requests.
- If you find this project useful, feel free to fork and modify it as you wish.

🔒 I consider this project “complete” and will maintain it only minimally going forward.
However, I intend to keep the AWS SDK for Rust and other dependencies up to date monthly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented exported `SOURCE` and `TARGET` environment variables from being interpreted as command-line arguments.
  - Improved validation for commands requiring source or target values.
  - Ensured invalid `TARGET` values do not interfere with bucket listing.
  - Added regression coverage across synchronization, copy, cleanup, utility, and listing commands.

- **Documentation**
  - Added release notes for version 1.7.0, including the environment-variable handling fix and updated engine components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->