### PR TITLE
Fix/broken pipe panic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,68 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.7.2] - 2026-08-04
+
+Bug-fix release. Writing to a pipe whose reader has already exited crashed s7cmd on several output paths — piping to
+`head 1` (where `head` treats `1` as a file name, fails to open it, and never reads its input), `head -1` when the
+output is larger than the pipe buffer, `grep -q`, or a pager closed early. This release makes every such path
+pipe-safe, in s7cmd's own code and in the four underlying libraries, which shipped the same fixes and are updated
+here. There are no changes to any subcommand's interface or to what is printed when the pipe stays open; upgrading
+requires nothing beyond installing the new binary.
+
+### Fixed
+
+#### All subcommands
+
+- Generating a shell completion script into a closed pipe (`s7cmd --auto-complete-shell bash | head 1`) panicked
+  inside clap_complete with `failed to write completion file: ... Broken pipe`. The script is now rendered to an
+  in-memory buffer and written pipe-safely: a closed pipe is treated as the normal end of a pipeline and the command
+  exits 0 — note that under `set -o pipefail` such pipelines now succeed where the panic previously failed them. Any
+  other stdout write failure (e.g. disk full on a redirect) now exits 1 with an error message instead of panicking.
+
+#### Util subcommands that print a report
+
+- Piping report output to a consumer that stops reading before the output ends no longer panics with
+  `failed printing to stdout: Broken pipe (os error 32)`. Every subcommand that prints a JSON report or a URL to
+  stdout was affected: the `get-bucket-*` family, `get-public-access-block`, `head-bucket`, `head-object`,
+  `get-object-tagging`, `list-object-annotations`, `get-object-annotation`, `put-object-annotation`, and `presign`.
+  A closed pipe is now treated as the normal end of a pipeline: the S3 operation has already completed, so the
+  command exits 0; any other stdout write failure exits 1 with an error message. `cp` streaming an object to stdout
+  (and `get-object-annotation` writing its payload to `-`) is unchanged: a download truncated by a vanished reader
+  is still reported as a failure, because there the bytes are the object itself, not a report about a completed
+  operation. `ls` and the tracing output already handled closed pipes and are unchanged.
+
+#### cp / mv
+
+- The transfer result lines printed to stderr on completion (`-> s3://...` and `Transferred: ...`) panicked when
+  stderr was a closed pipe (e.g. `2>&1 | head`). They are now written best-effort, matching the tracing output,
+  which already ignored a closed stderr.
+
+#### batch-run
+
+- The end-of-run summary (both the human-readable line and the `--json-tracing` JSON object) panicked when stderr
+  was a closed pipe, turning an otherwise fully successful run into exit 101 (abnormal termination) after every
+  line had already executed. The summary is now written best-effort.
+
+### Changed
+
+- s3sync `v1.61.1 -> v1.61.2`
+- s3util-rs `v1.9.1 -> v1.9.2`
+- s3rm-rs `v1.5.1 -> v1.5.2`
+- s3ls-rs `v1.2.1 -> v1.2.2`
+
+These are the upstream releases of the same broken-pipe fixes; s7cmd vendors its command frontends, so the fixes
+are ported into the vendored code as well.
+
+### Underlying libraries
+
+```toml
+s3sync = "=1.61.2"
+s3util-rs = "=1.9.2"
+s3rm-rs = "=1.5.2"
+s3ls-rs = "=1.2.2"
+```
+
 ## [1.7.1] - 2026-07-26
 
 Dependency-refresh release. All four underlying libraries are updated to their 2026-07-26 releases, which are

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2852,9 +2852,9 @@ checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "s3ls-rs"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44ff1fd500ff029c4f24384b6599ce1b6a5b95913c33f7352aef75aec713e12c"
+checksum = "9a85ed2b4b885cd62716c87f08b8d9d4fdcaa6aaf0a784cda25cc828337615d5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2888,9 +2888,9 @@ dependencies = [
 
 [[package]]
 name = "s3rm-rs"
-version = "1.5.1"
+version = "1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49f76aee2ea4798bccaddf7608ad6e8de1d5d15a60e4e2a9160cabf0a12c7c80"
+checksum = "5f031dbfd066a66e25872e4058ae90715926754d15ca4c0c676d77b3451a01c0"
 dependencies = [
  "anyhow",
  "async-channel",
@@ -2930,9 +2930,9 @@ dependencies = [
 
 [[package]]
 name = "s3sync"
-version = "1.61.1"
+version = "1.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4f940358b686c9b0d8c8e9924da750e292723d2d13e594202c0333823e334e0"
+checksum = "c4eb0db3ebc89239ef047457d36922a94ecc2d3ed6450cdc1cf3bfebb655fefb"
 dependencies = [
  "anyhow",
  "async-channel",
@@ -2992,9 +2992,9 @@ dependencies = [
 
 [[package]]
 name = "s3util-rs"
-version = "1.9.1"
+version = "1.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c7a85e42109a074ddd1c2378c2575db0a6e950e66c45a9e57a17474d53d1e1c"
+checksum = "5c9d549afb12b3ef8f70113354cffe26b2bb4e7ff700cdd991fbc597a2931ea6"
 dependencies = [
  "anyhow",
  "async-channel",
@@ -3051,7 +3051,7 @@ dependencies = [
 
 [[package]]
 name = "s7cmd"
-version = "1.7.1"
+version = "1.7.2"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "s7cmd"
-version = "1.7.1"
+version = "1.7.2"
 edition = "2024"
 rust-version = "1.94.1"
 license = "Apache-2.0"
@@ -16,11 +16,11 @@ categories = ["command-line-utilities", "filesystem"]
 # s3sync's `lua_support` is in its default features; Lua flags
 # (--filter-callback-lua-script, etc.) automatically appear under
 # `s7cmd sync --help`. Use default-features = false to opt out.
-s3sync     = "=1.61.1"
-s3util-rs  = "=1.9.1"
+s3sync     = "=1.61.2"
+s3util-rs  = "=1.9.2"
 # Vendored bin code is sourced from these versions; pin minor.
-s3rm-rs    = "=1.5.1"
-s3ls-rs    = "=1.2.1"
+s3rm-rs    = "=1.5.2"
+s3ls-rs    = "=1.2.2"
 
 # Build-info for `s7cmd --version` (gated behind the `version` feature).
 shadow-rs = { version = "2", optional = true, default-features = false }

--- a/README.md
+++ b/README.md
@@ -812,7 +812,20 @@ replication, transfer acceleration, request payment). For any S3 use
 case outside that scope, use a more comprehensive tool such as the
 [AWS CLI](https://aws.amazon.com/cli/) (`aws s3api`).
 
-s7cmd targets **Amazon S3** as its only supported platform.
+s7cmd targets **Amazon S3** as its only supported platform and is
+optimized for Amazon S3 performance.
+
+> Note that "optimized for Amazon S3 performance" includes the
+> allowed request rate: Amazon S3 supports at least 3,500
+> PUT/COPY/POST/DELETE or 5,500 GET/HEAD requests per second per
+> partitioned prefix, and s7cmd's parallel `ls`, `clean`, and
+> `sync` engines assume that capacity. The request rate allowed by
+> S3-compatible storage may differ significantly, so running `ls`,
+> `clean`, or `sync` against S3-compatible storage can exceed the
+> service's rate limit. The request rate can be capped with each
+> command's rate-limit option (`--rate-limit-api` for `ls`,
+> `--rate-limit-objects` for `clean` and `sync`).
+
 S3-compatible storage (MinIO, Cloudflare R2, Backblaze B2, Wasabi,
 Ceph RGW, DigitalOcean Spaces, IBM COS, and similar) is provided
 strictly **as-is**, with **absolutely no support or assistance** —
@@ -825,8 +838,14 @@ generated from AWS service models and assumes Amazon S3 semantics
 (checksum headers, endpoint resolution, signing variants, response
 schemas); features that depend on AWS-specific semantics, such as
 CRC64NVME checksums or newer S3 API additions, may not work against
-non-AWS endpoints. Bug reports, questions, and assistance requests
-regarding S3-compatible storage will not be addressed.
+non-AWS endpoints. In practice, most s7cmd subcommands are not
+supported on S3-compatible storage and are therefore unlikely to
+work: the bucket-configuration family drives management APIs that
+such services implement partially or not at all, and `rename`,
+`restore-object`, and the object-annotation subcommands depend on
+Amazon-S3-only APIs and checksum semantics. Bug reports, questions,
+and assistance requests regarding S3-compatible storage will not be
+addressed.
 
 s7cmd is **not** intended to be a drop-in replacement for, or
 behaviorally compatible with, any other S3 client — including the

--- a/src/batch_run/mod.rs
+++ b/src/batch_run/mod.rs
@@ -2,7 +2,7 @@
 
 use anyhow::Result;
 use clap::FromArgMatches;
-use std::io::BufRead;
+use std::io::{BufRead, Write};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 
@@ -324,7 +324,14 @@ async fn run_read_all(args: BatchRunArgs) -> i32 {
     };
 
     if !args.no_summary {
-        eprintln!("{}", format_summary(&summary, args.json_tracing));
+        // eprintln! panics when stderr is a closed pipe (`s7cmd batch-run
+        // ... 2>&1 | head`); the summary is best-effort, like the tracing
+        // output, which already ignores a closed stderr.
+        let _ = writeln!(
+            std::io::stderr(),
+            "{}",
+            format_summary(&summary, args.json_tracing)
+        );
     }
 
     code
@@ -412,7 +419,12 @@ async fn run_streaming(args: BatchRunArgs) -> i32 {
     };
 
     if !args.no_summary {
-        eprintln!("{}", format_summary(&summary, args.json_tracing));
+        // Best-effort for the same reason as in `run_read_all`.
+        let _ = writeln!(
+            std::io::stderr(),
+            "{}",
+            format_summary(&summary, args.json_tracing)
+        );
     }
 
     final_code

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,7 @@
 // s7cmd entry point. The per-subcommand dispatch table lives in
 // `dispatch.rs` so it can be reused by `batch_run`.
 
+use std::io::Write;
 use std::process::ExitCode;
 
 use clap::FromArgMatches;
@@ -11,6 +12,7 @@ mod clean_bin;
 mod cli;
 mod dispatch;
 mod ls_bin;
+mod pipe_safe;
 mod sync_bin;
 mod util_bin;
 
@@ -29,8 +31,7 @@ async fn main() -> ExitCode {
     // declares the field, but we clear the long name so the parser rejects
     // `s7cmd <sub> --auto-complete-shell ...`).
     if let Some(shell) = cli_args.auto_complete_shell {
-        generate(shell, &mut cli_command(), "s7cmd", &mut std::io::stdout());
-        return ExitCode::SUCCESS;
+        return print_completion_script(shell);
     }
 
     // arg_required_else_help on the Cli ensures we always have a command
@@ -43,6 +44,37 @@ async fn main() -> ExitCode {
 
     let exit_code = dispatch::dispatch(command).await;
     ExitCode::from(exit_code as u8)
+}
+
+/// Render the shell-completion script for `shell` and print it pipe-safely.
+///
+/// clap_complete's generators panic on writer errors ("failed to write
+/// completion file"), so they never touch stdout directly: the script is
+/// rendered into an infallible in-memory buffer and written in one
+/// pipe-safe pass. A reader that exits early
+/// (`s7cmd --auto-complete-shell bash | head 1`) yields exit 0; any other
+/// stdout write error is reported on stderr with exit 1.
+fn print_completion_script(shell: clap_complete::shells::Shell) -> ExitCode {
+    match pipe_safe::write_all_pipe_safe(&render_completion_script(shell)) {
+        Ok(()) => ExitCode::SUCCESS,
+        Err(e) => {
+            // Tracing is never initialized on this path; best-effort stderr.
+            let _ = writeln!(
+                std::io::stderr(),
+                "error: failed to write completion script: {e}"
+            );
+            ExitCode::FAILURE
+        }
+    }
+}
+
+/// Render the completion script for the whole s7cmd CLI into memory.
+/// Infallible: clap_complete only fails through its writer, and writes to
+/// a `Vec<u8>` cannot fail.
+fn render_completion_script(shell: clap_complete::shells::Shell) -> Vec<u8> {
+    let mut script = Vec::new();
+    generate(shell, &mut cli_command(), "s7cmd", &mut script);
+    script
 }
 
 /// Initialize the global tracing subscriber from whichever subcommand
@@ -135,5 +167,34 @@ fn init_tracing_for(cmd: &Cmd) {
 
     if let Some(tc) = tc {
         util_bin::tracing_init::init_tracing(&tc);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use clap_complete::shells::Shell;
+
+    /// The in-memory rendering must produce a real s7cmd completion script
+    /// for every supported shell. Rendering to a buffer is what keeps
+    /// clap_complete's panicking writer path away from stdout; the
+    /// closed-pipe behavior itself is pinned process-level in
+    /// `tests/cli_broken_pipe.rs`.
+    #[test]
+    fn render_completion_script_produces_s7cmd_completions() {
+        for shell in [
+            Shell::Bash,
+            Shell::Zsh,
+            Shell::Fish,
+            Shell::PowerShell,
+            Shell::Elvish,
+        ] {
+            let script = render_completion_script(shell);
+            let text = String::from_utf8(script).expect("completion script must be UTF-8");
+            assert!(
+                text.contains("s7cmd"),
+                "{shell:?} completion script must mention s7cmd"
+            );
+        }
     }
 }

--- a/src/pipe_safe.rs
+++ b/src/pipe_safe.rs
@@ -1,0 +1,174 @@
+// Vendored from s3util-rs@1.9.2
+//   src/bin/s3util/pipe_safe.rs
+// Adjustments: doc comment adapted to s7cmd — upstream ships one copy per
+//              binary (s3sync / s3rm / s3ls carry a write_all-only variant);
+//              s7cmd keeps a single shared module at the crate root so the
+//              vendored util_bin printers keep their upstream
+//              `crate::pipe_safe` import path and `main.rs` can reuse it for
+//              completion scripts. Added the flush-error propagation unit
+//              test from the s3rm-rs 1.5.2 copy.
+
+//! Pipe-safe stdout printing.
+//!
+//! `println!` (and any direct stdout write) panics when stdout is a pipe
+//! whose reader has already gone away — piping to a `head`/`grep -q`/pager
+//! that exited before the output ended, or `s7cmd get-bucket-versioning
+//! s3://bucket | head 1`, where `head` fails to open the file `1` and never
+//! reads. Report output and pre-rendered output go through these helpers
+//! instead: `BrokenPipe` is swallowed — by the time a report is printed the
+//! S3 operation has already completed, and a reader that stops early is a
+//! normal way for a pipeline to end — so the command still exits 0. Any
+//! other write error (full disk or I/O error on a redirect) is propagated
+//! so the command fails loudly instead of silently dropping output.
+//!
+//! Used by the vendored `util_bin` report printers (the `get-*` family,
+//! `head-*`, `presign`, and the annotation subcommands) and by `main.rs`
+//! for `--auto-complete-shell` scripts. The data-transfer paths are
+//! intentionally different and unchanged: `cp` to stdout and
+//! `get-object-annotation` payload output deliver object bytes whose
+//! truncation is a real failure, and both already report `BrokenPipe` as
+//! an error rather than panicking. The stderr counterpart for tracing
+//! output is each vendored bin's `PipeSafeWriter`; `ls` listing output
+//! already treats `BrokenPipe` as end-of-pipeline inside `ls_bin`.
+
+use std::io::{ErrorKind, Write};
+
+/// `println!("{text}")` minus the BrokenPipe panic: the line goes to
+/// stdout, and a closed pipe is reported as success.
+pub fn println_pipe_safe(text: &str) -> std::io::Result<()> {
+    writeln_ignoring_broken_pipe(&mut std::io::stdout().lock(), text)
+}
+
+/// Write `bytes` to stdout as-is (no trailing newline), swallowing
+/// BrokenPipe. Used for pre-rendered output such as shell-completion
+/// scripts.
+pub fn write_all_pipe_safe(bytes: &[u8]) -> std::io::Result<()> {
+    write_all_ignoring_broken_pipe(&mut std::io::stdout().lock(), bytes)
+}
+
+fn writeln_ignoring_broken_pipe(writer: &mut impl Write, text: &str) -> std::io::Result<()> {
+    ignore_broken_pipe(writeln!(writer, "{text}").and_then(|()| writer.flush()))
+}
+
+fn write_all_ignoring_broken_pipe(writer: &mut impl Write, bytes: &[u8]) -> std::io::Result<()> {
+    ignore_broken_pipe(writer.write_all(bytes).and_then(|()| writer.flush()))
+}
+
+fn ignore_broken_pipe(result: std::io::Result<()>) -> std::io::Result<()> {
+    match result {
+        Err(e) if e.kind() == ErrorKind::BrokenPipe => Ok(()),
+        other => other,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Fails writes (or, with `fail_flush`, only the flush) with `kind`.
+    /// The real closed-pipe scenario is exercised process-level by
+    /// `tests/cli_broken_pipe.rs`.
+    struct FailWriter {
+        kind: ErrorKind,
+        fail_flush: bool,
+    }
+
+    impl Write for FailWriter {
+        fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+            if self.fail_flush {
+                Ok(buf.len())
+            } else {
+                Err(std::io::Error::new(self.kind, "simulated write failure"))
+            }
+        }
+        fn flush(&mut self) -> std::io::Result<()> {
+            if self.fail_flush {
+                Err(std::io::Error::new(self.kind, "simulated flush failure"))
+            } else {
+                Ok(())
+            }
+        }
+    }
+
+    #[test]
+    fn writeln_appends_newline_and_passes_through() {
+        let mut buf = Vec::new();
+        writeln_ignoring_broken_pipe(&mut buf, "{\n  \"Status\": \"Enabled\"\n}").unwrap();
+        assert_eq!(buf, b"{\n  \"Status\": \"Enabled\"\n}\n");
+    }
+
+    #[test]
+    fn writeln_swallows_broken_pipe_on_write() {
+        let mut writer = FailWriter {
+            kind: ErrorKind::BrokenPipe,
+            fail_flush: false,
+        };
+        writeln_ignoring_broken_pipe(&mut writer, "line").unwrap();
+    }
+
+    #[test]
+    fn writeln_swallows_broken_pipe_on_flush() {
+        let mut writer = FailWriter {
+            kind: ErrorKind::BrokenPipe,
+            fail_flush: true,
+        };
+        writeln_ignoring_broken_pipe(&mut writer, "line").unwrap();
+    }
+
+    #[test]
+    fn writeln_propagates_other_errors() {
+        // A failed redirect (disk full, I/O error) must still fail the
+        // command — only a vanished reader is benign.
+        let mut writer = FailWriter {
+            kind: ErrorKind::StorageFull,
+            fail_flush: false,
+        };
+        let err = writeln_ignoring_broken_pipe(&mut writer, "line").unwrap_err();
+        assert_eq!(err.kind(), ErrorKind::StorageFull);
+    }
+
+    #[test]
+    fn write_all_passes_bytes_through_verbatim() {
+        let mut buf = Vec::new();
+        write_all_ignoring_broken_pipe(&mut buf, b"complete -c s7cmd\n").unwrap();
+        assert_eq!(buf, b"complete -c s7cmd\n");
+    }
+
+    #[test]
+    fn write_all_swallows_broken_pipe_on_write() {
+        let mut writer = FailWriter {
+            kind: ErrorKind::BrokenPipe,
+            fail_flush: false,
+        };
+        write_all_ignoring_broken_pipe(&mut writer, b"data").unwrap();
+    }
+
+    #[test]
+    fn write_all_swallows_broken_pipe_on_flush() {
+        let mut writer = FailWriter {
+            kind: ErrorKind::BrokenPipe,
+            fail_flush: true,
+        };
+        write_all_ignoring_broken_pipe(&mut writer, b"data").unwrap();
+    }
+
+    #[test]
+    fn write_all_propagates_other_errors() {
+        let mut writer = FailWriter {
+            kind: ErrorKind::StorageFull,
+            fail_flush: false,
+        };
+        let err = write_all_ignoring_broken_pipe(&mut writer, b"data").unwrap_err();
+        assert_eq!(err.kind(), ErrorKind::StorageFull);
+    }
+
+    #[test]
+    fn write_all_propagates_other_errors_on_flush() {
+        let mut writer = FailWriter {
+            kind: ErrorKind::StorageFull,
+            fail_flush: true,
+        };
+        let err = write_all_ignoring_broken_pipe(&mut writer, b"data").unwrap_err();
+        assert_eq!(err.kind(), ErrorKind::StorageFull);
+    }
+}

--- a/src/util_bin/cli/get_bucket_accelerate_configuration.rs
+++ b/src/util_bin/cli/get_bucket_accelerate_configuration.rs
@@ -1,6 +1,7 @@
 // Vendored from s3util-rs@1.3.0
 //   src/bin/s3util/cli/get_bucket_accelerate_configuration.rs
 // Adjustments: no tests stripped; rewrote crate::cli → super
+//              Report println made pipe-safe (ported from s3util-rs 1.9.2).
 use anyhow::Result;
 use tracing::info;
 
@@ -8,6 +9,8 @@ use s3util_rs::config::ClientConfig;
 use s3util_rs::config::args::get_bucket_accelerate_configuration::GetBucketAccelerateConfigurationArgs;
 use s3util_rs::output::json::get_bucket_accelerate_configuration_to_json;
 use s3util_rs::storage::s3::api::{self, HeadError};
+
+use crate::pipe_safe::println_pipe_safe;
 
 use super::ExitStatus;
 
@@ -34,7 +37,7 @@ pub async fn run_get_bucket_accelerate_configuration(
                 info!(bucket = %bucket, "Bucket Transfer Acceleration not configured.");
             } else {
                 let pretty = serde_json::to_string_pretty(&json)?;
-                println!("{pretty}");
+                println_pipe_safe(&pretty)?;
             }
             Ok(ExitStatus::Success)
         }

--- a/src/util_bin/cli/get_bucket_cors.rs
+++ b/src/util_bin/cli/get_bucket_cors.rs
@@ -1,12 +1,15 @@
 // Vendored from s3util-rs@0.2.2
 //   src/bin/s3util/cli/get_bucket_cors.rs
 // Adjustments: no tests stripped; rewrote crate::cli → super
+//              Report println made pipe-safe (ported from s3util-rs 1.9.2).
 use anyhow::Result;
 
 use s3util_rs::config::ClientConfig;
 use s3util_rs::config::args::get_bucket_cors::GetBucketCorsArgs;
 use s3util_rs::output::json::get_bucket_cors_to_json;
 use s3util_rs::storage::s3::api::{self, HeadError};
+
+use crate::pipe_safe::println_pipe_safe;
 
 use super::ExitStatus;
 
@@ -29,7 +32,7 @@ pub async fn run_get_bucket_cors(
         Ok(out) => {
             let json = get_bucket_cors_to_json(&out);
             let pretty = serde_json::to_string_pretty(&json)?;
-            println!("{pretty}");
+            println_pipe_safe(&pretty)?;
             Ok(ExitStatus::Success)
         }
         Err(HeadError::BucketNotFound) => {

--- a/src/util_bin/cli/get_bucket_encryption.rs
+++ b/src/util_bin/cli/get_bucket_encryption.rs
@@ -1,12 +1,15 @@
 // Vendored from s3util-rs@0.2.2
 //   src/bin/s3util/cli/get_bucket_encryption.rs
 // Adjustments: no tests stripped; rewrote crate::cli → super
+//              Report println made pipe-safe (ported from s3util-rs 1.9.2).
 use anyhow::Result;
 
 use s3util_rs::config::ClientConfig;
 use s3util_rs::config::args::get_bucket_encryption::GetBucketEncryptionArgs;
 use s3util_rs::output::json::get_bucket_encryption_to_json;
 use s3util_rs::storage::s3::api::{self, HeadError};
+
+use crate::pipe_safe::println_pipe_safe;
 
 use super::ExitStatus;
 
@@ -30,7 +33,7 @@ pub async fn run_get_bucket_encryption(
         Ok(out) => {
             let json = get_bucket_encryption_to_json(&out);
             let pretty = serde_json::to_string_pretty(&json)?;
-            println!("{pretty}");
+            println_pipe_safe(&pretty)?;
             Ok(ExitStatus::Success)
         }
         Err(HeadError::BucketNotFound) => {

--- a/src/util_bin/cli/get_bucket_lifecycle_configuration.rs
+++ b/src/util_bin/cli/get_bucket_lifecycle_configuration.rs
@@ -1,12 +1,15 @@
 // Vendored from s3util-rs@0.2.2
 //   src/bin/s3util/cli/get_bucket_lifecycle_configuration.rs
 // Adjustments: no tests stripped; rewrote crate::cli → super
+//              Report println made pipe-safe (ported from s3util-rs 1.9.2).
 use anyhow::Result;
 
 use s3util_rs::config::ClientConfig;
 use s3util_rs::config::args::get_bucket_lifecycle_configuration::GetBucketLifecycleConfigurationArgs;
 use s3util_rs::output::json::get_bucket_lifecycle_configuration_to_json;
 use s3util_rs::storage::s3::api::{self, HeadError};
+
+use crate::pipe_safe::println_pipe_safe;
 
 use super::ExitStatus;
 
@@ -30,7 +33,7 @@ pub async fn run_get_bucket_lifecycle_configuration(
         Ok(out) => {
             let json = get_bucket_lifecycle_configuration_to_json(&out);
             let pretty = serde_json::to_string_pretty(&json)?;
-            println!("{pretty}");
+            println_pipe_safe(&pretty)?;
             Ok(ExitStatus::Success)
         }
         Err(HeadError::BucketNotFound) => {

--- a/src/util_bin/cli/get_bucket_logging.rs
+++ b/src/util_bin/cli/get_bucket_logging.rs
@@ -1,6 +1,7 @@
 // Vendored from s3util-rs@0.2.2
 //   src/bin/s3util/cli/get_bucket_logging.rs
 // Adjustments: no tests stripped; rewrote crate::cli → super
+//              Report println made pipe-safe (ported from s3util-rs 1.9.2).
 use anyhow::Result;
 use tracing::info;
 
@@ -8,6 +9,8 @@ use s3util_rs::config::ClientConfig;
 use s3util_rs::config::args::get_bucket_logging::GetBucketLoggingArgs;
 use s3util_rs::output::json::get_bucket_logging_to_json;
 use s3util_rs::storage::s3::api::{self, HeadError};
+
+use crate::pipe_safe::println_pipe_safe;
 
 use super::ExitStatus;
 
@@ -35,7 +38,7 @@ pub async fn run_get_bucket_logging(
                 info!(bucket = %bucket, "Bucket logging not configured.");
             } else {
                 let pretty = serde_json::to_string_pretty(&json)?;
-                println!("{pretty}");
+                println_pipe_safe(&pretty)?;
             }
             Ok(ExitStatus::Success)
         }

--- a/src/util_bin/cli/get_bucket_notification_configuration.rs
+++ b/src/util_bin/cli/get_bucket_notification_configuration.rs
@@ -1,6 +1,7 @@
 // Vendored from s3util-rs@0.2.2
 //   src/bin/s3util/cli/get_bucket_notification_configuration.rs
 // Adjustments: no tests stripped; rewrote crate::cli → super
+//              Report println made pipe-safe (ported from s3util-rs 1.9.2).
 use anyhow::Result;
 use tracing::info;
 
@@ -8,6 +9,8 @@ use s3util_rs::config::ClientConfig;
 use s3util_rs::config::args::get_bucket_notification_configuration::GetBucketNotificationConfigurationArgs;
 use s3util_rs::output::json::get_bucket_notification_configuration_to_json;
 use s3util_rs::storage::s3::api::{self, HeadError};
+
+use crate::pipe_safe::println_pipe_safe;
 
 use super::ExitStatus;
 
@@ -38,7 +41,7 @@ pub async fn run_get_bucket_notification_configuration(
                 info!(bucket = %bucket, "Bucket notification configuration not configured.");
             } else {
                 let pretty = serde_json::to_string_pretty(&json)?;
-                println!("{pretty}");
+                println_pipe_safe(&pretty)?;
             }
             Ok(ExitStatus::Success)
         }

--- a/src/util_bin/cli/get_bucket_policy.rs
+++ b/src/util_bin/cli/get_bucket_policy.rs
@@ -1,6 +1,7 @@
 // Vendored from s3util-rs@0.2.0
 //   src/bin/s3util/cli/get_bucket_policy.rs
 // Adjustments: stripped #[cfg(test)] mod tests; rewrote crate::cli → super
+//              Report println made pipe-safe (ported from s3util-rs 1.9.2).
 
 use anyhow::Result;
 
@@ -8,6 +9,8 @@ use s3util_rs::config::ClientConfig;
 use s3util_rs::config::args::get_bucket_policy::GetBucketPolicyArgs;
 use s3util_rs::output::json::get_bucket_policy_to_json;
 use s3util_rs::storage::s3::api::{self, HeadError};
+
+use crate::pipe_safe::println_pipe_safe;
 
 use super::ExitStatus;
 
@@ -38,7 +41,7 @@ pub async fn run_get_bucket_policy(
             } else {
                 serde_json::to_string_pretty(&get_bucket_policy_to_json(&out))?
             };
-            println!("{pretty}");
+            println_pipe_safe(&pretty)?;
             Ok(ExitStatus::Success)
         }
         Err(HeadError::BucketNotFound) => {

--- a/src/util_bin/cli/get_bucket_policy_status.rs
+++ b/src/util_bin/cli/get_bucket_policy_status.rs
@@ -1,12 +1,15 @@
 // Vendored from s3util-rs@1.3.0
 //   src/bin/s3util/cli/get_bucket_policy_status.rs
 // Adjustments: no tests stripped; rewrote crate::cli → super
+//              Report println made pipe-safe (ported from s3util-rs 1.9.2).
 use anyhow::Result;
 
 use s3util_rs::config::ClientConfig;
 use s3util_rs::config::args::get_bucket_policy_status::GetBucketPolicyStatusArgs;
 use s3util_rs::output::json::get_bucket_policy_status_to_json;
 use s3util_rs::storage::s3::api::{self, HeadError};
+
+use crate::pipe_safe::println_pipe_safe;
 
 use super::ExitStatus;
 
@@ -30,7 +33,7 @@ pub async fn run_get_bucket_policy_status(
         Ok(out) => {
             let json = get_bucket_policy_status_to_json(&out);
             let pretty = serde_json::to_string_pretty(&json)?;
-            println!("{pretty}");
+            println_pipe_safe(&pretty)?;
             Ok(ExitStatus::Success)
         }
         Err(HeadError::BucketNotFound) => {

--- a/src/util_bin/cli/get_bucket_replication.rs
+++ b/src/util_bin/cli/get_bucket_replication.rs
@@ -1,12 +1,15 @@
 // Vendored from s3util-rs@1.3.0
 //   src/bin/s3util/cli/get_bucket_replication.rs
 // Adjustments: no tests stripped; rewrote crate::cli → super
+//              Report println made pipe-safe (ported from s3util-rs 1.9.2).
 use anyhow::Result;
 
 use s3util_rs::config::ClientConfig;
 use s3util_rs::config::args::get_bucket_replication::GetBucketReplicationArgs;
 use s3util_rs::output::json::get_bucket_replication_to_json;
 use s3util_rs::storage::s3::api::{self, HeadError};
+
+use crate::pipe_safe::println_pipe_safe;
 
 use super::ExitStatus;
 
@@ -30,7 +33,7 @@ pub async fn run_get_bucket_replication(
         Ok(out) => {
             let json = get_bucket_replication_to_json(&out);
             let pretty = serde_json::to_string_pretty(&json)?;
-            println!("{pretty}");
+            println_pipe_safe(&pretty)?;
             Ok(ExitStatus::Success)
         }
         Err(HeadError::BucketNotFound) => {

--- a/src/util_bin/cli/get_bucket_request_payment.rs
+++ b/src/util_bin/cli/get_bucket_request_payment.rs
@@ -1,12 +1,15 @@
 // Vendored from s3util-rs@1.3.0
 //   src/bin/s3util/cli/get_bucket_request_payment.rs
 // Adjustments: no tests stripped; rewrote crate::cli → super
+//              Report println made pipe-safe (ported from s3util-rs 1.9.2).
 use anyhow::Result;
 
 use s3util_rs::config::ClientConfig;
 use s3util_rs::config::args::get_bucket_request_payment::GetBucketRequestPaymentArgs;
 use s3util_rs::output::json::get_bucket_request_payment_to_json;
 use s3util_rs::storage::s3::api::{self, HeadError};
+
+use crate::pipe_safe::println_pipe_safe;
 
 use super::ExitStatus;
 
@@ -28,7 +31,7 @@ pub async fn run_get_bucket_request_payment(
         Ok(out) => {
             let json = get_bucket_request_payment_to_json(&out);
             let pretty = serde_json::to_string_pretty(&json)?;
-            println!("{pretty}");
+            println_pipe_safe(&pretty)?;
             Ok(ExitStatus::Success)
         }
         Err(HeadError::BucketNotFound) | Err(HeadError::NotFound) => {

--- a/src/util_bin/cli/get_bucket_tagging.rs
+++ b/src/util_bin/cli/get_bucket_tagging.rs
@@ -1,6 +1,7 @@
 // Vendored from s3util-rs@0.2.0
 //   src/bin/s3util/cli/get_bucket_tagging.rs
 // Adjustments: no tests stripped; rewrote crate::cli → super
+//              Report println made pipe-safe (ported from s3util-rs 1.9.2).
 
 use anyhow::Result;
 
@@ -8,6 +9,8 @@ use s3util_rs::config::ClientConfig;
 use s3util_rs::config::args::get_bucket_tagging::GetBucketTaggingArgs;
 use s3util_rs::output::json::get_bucket_tagging_to_json;
 use s3util_rs::storage::s3::api::{self, HeadError};
+
+use crate::pipe_safe::println_pipe_safe;
 
 use super::ExitStatus;
 
@@ -32,7 +35,7 @@ pub async fn run_get_bucket_tagging(
         Ok(out) => {
             let json = get_bucket_tagging_to_json(&out);
             let pretty = serde_json::to_string_pretty(&json)?;
-            println!("{pretty}");
+            println_pipe_safe(&pretty)?;
             Ok(ExitStatus::Success)
         }
         Err(HeadError::BucketNotFound) => {

--- a/src/util_bin/cli/get_bucket_versioning.rs
+++ b/src/util_bin/cli/get_bucket_versioning.rs
@@ -1,6 +1,7 @@
 // Vendored from s3util-rs@0.2.0
 //   src/bin/s3util/cli/get_bucket_versioning.rs
 // Adjustments: no tests stripped; rewrote crate::cli → super
+//              Report println made pipe-safe (ported from s3util-rs 1.9.2).
 use anyhow::Result;
 use tracing::info;
 
@@ -8,6 +9,8 @@ use s3util_rs::config::ClientConfig;
 use s3util_rs::config::args::get_bucket_versioning::GetBucketVersioningArgs;
 use s3util_rs::output::json::get_bucket_versioning_to_json;
 use s3util_rs::storage::s3::api::{self, HeadError};
+
+use crate::pipe_safe::println_pipe_safe;
 
 use super::ExitStatus;
 
@@ -36,7 +39,7 @@ pub async fn run_get_bucket_versioning(
                 info!(bucket = %bucket, "Bucket versioning not configured.");
             } else {
                 let pretty = serde_json::to_string_pretty(&json)?;
-                println!("{pretty}");
+                println_pipe_safe(&pretty)?;
             }
             Ok(ExitStatus::Success)
         }

--- a/src/util_bin/cli/get_bucket_website.rs
+++ b/src/util_bin/cli/get_bucket_website.rs
@@ -1,12 +1,15 @@
 // Vendored from s3util-rs@0.2.2
 //   src/bin/s3util/cli/get_bucket_website.rs
 // Adjustments: no tests stripped; rewrote crate::cli → super
+//              Report println made pipe-safe (ported from s3util-rs 1.9.2).
 use anyhow::Result;
 
 use s3util_rs::config::ClientConfig;
 use s3util_rs::config::args::get_bucket_website::GetBucketWebsiteArgs;
 use s3util_rs::output::json::get_bucket_website_to_json;
 use s3util_rs::storage::s3::api::{self, HeadError};
+
+use crate::pipe_safe::println_pipe_safe;
 
 use super::ExitStatus;
 
@@ -29,7 +32,7 @@ pub async fn run_get_bucket_website(
         Ok(out) => {
             let json = get_bucket_website_to_json(&out);
             let pretty = serde_json::to_string_pretty(&json)?;
-            println!("{pretty}");
+            println_pipe_safe(&pretty)?;
             Ok(ExitStatus::Success)
         }
         Err(HeadError::BucketNotFound) => {

--- a/src/util_bin/cli/get_object_annotation.rs
+++ b/src/util_bin/cli/get_object_annotation.rs
@@ -7,6 +7,7 @@
 //              and verify_saved_file_err_when_file_unreadable unit tests. The
 //              detect_checksum / check_integrity unsupported-algorithm handling
 //              tracks upstream 1.7.0.
+//              Report println made pipe-safe (ported from s3util-rs 1.9.2).
 
 use std::io::Write as _;
 use std::path::Path;
@@ -23,6 +24,8 @@ use s3util_rs::output::json::get_object_annotation_to_json;
 use s3util_rs::storage::annotation;
 use s3util_rs::storage::checksum::AdditionalChecksum;
 use s3util_rs::storage::s3::api::{self, GetObjectAnnotationParams, ObjectAnnotationError};
+
+use crate::pipe_safe::println_pipe_safe;
 
 use super::ExitStatus;
 
@@ -377,7 +380,7 @@ pub async fn run_get_object_annotation(
         &key,
     )?;
 
-    println!("{}", serde_json::to_string_pretty(&json)?);
+    println_pipe_safe(&serde_json::to_string_pretty(&json)?)?;
     let outcome = if verified {
         "written and verified"
     } else {

--- a/src/util_bin/cli/get_object_tagging.rs
+++ b/src/util_bin/cli/get_object_tagging.rs
@@ -1,6 +1,7 @@
 // Vendored from s3util-rs@0.2.0
 //   src/bin/s3util/cli/get_object_tagging.rs
 // Adjustments: no tests stripped; rewrote crate::cli → super
+//              Report println made pipe-safe (ported from s3util-rs 1.9.2).
 
 use anyhow::Result;
 
@@ -8,6 +9,8 @@ use s3util_rs::config::ClientConfig;
 use s3util_rs::config::args::get_object_tagging::GetObjectTaggingArgs;
 use s3util_rs::output::json::get_object_tagging_to_json;
 use s3util_rs::storage::s3::api::{self, HeadError};
+
+use crate::pipe_safe::println_pipe_safe;
 
 use super::ExitStatus;
 
@@ -39,7 +42,7 @@ pub async fn run_get_object_tagging(
         Ok(out) => {
             let json = get_object_tagging_to_json(&out);
             let pretty = serde_json::to_string_pretty(&json)?;
-            println!("{pretty}");
+            println_pipe_safe(&pretty)?;
             Ok(ExitStatus::Success)
         }
         Err(HeadError::BucketNotFound) => {

--- a/src/util_bin/cli/get_public_access_block.rs
+++ b/src/util_bin/cli/get_public_access_block.rs
@@ -1,12 +1,15 @@
 // Vendored from s3util-rs@0.2.2
 //   src/bin/s3util/cli/get_public_access_block.rs
 // Adjustments: no tests stripped; rewrote crate::cli → super
+//              Report println made pipe-safe (ported from s3util-rs 1.9.2).
 use anyhow::Result;
 
 use s3util_rs::config::ClientConfig;
 use s3util_rs::config::args::get_public_access_block::GetPublicAccessBlockArgs;
 use s3util_rs::output::json::get_public_access_block_to_json;
 use s3util_rs::storage::s3::api::{self, HeadError};
+
+use crate::pipe_safe::println_pipe_safe;
 
 use super::ExitStatus;
 
@@ -30,7 +33,7 @@ pub async fn run_get_public_access_block(
         Ok(out) => {
             let json = get_public_access_block_to_json(&out);
             let pretty = serde_json::to_string_pretty(&json)?;
-            println!("{pretty}");
+            println_pipe_safe(&pretty)?;
             Ok(ExitStatus::Success)
         }
         Err(HeadError::BucketNotFound) => {

--- a/src/util_bin/cli/head_bucket.rs
+++ b/src/util_bin/cli/head_bucket.rs
@@ -1,6 +1,7 @@
 // Vendored from s3util-rs@0.2.0
 //   src/bin/s3util/cli/head_bucket.rs
 // Adjustments: no tests stripped; rewrote crate::cli → super
+//              Report println made pipe-safe (ported from s3util-rs 1.9.2).
 
 use anyhow::Result;
 
@@ -8,6 +9,8 @@ use s3util_rs::config::ClientConfig;
 use s3util_rs::config::args::head_bucket::HeadBucketArgs;
 use s3util_rs::output::json::head_bucket_to_json;
 use s3util_rs::storage::s3::api::{self, HeadError};
+
+use crate::pipe_safe::println_pipe_safe;
 
 use super::ExitStatus;
 
@@ -30,7 +33,7 @@ pub async fn run_head_bucket(
         Ok(out) => {
             let json = head_bucket_to_json(&out);
             let pretty = serde_json::to_string_pretty(&json)?;
-            println!("{pretty}");
+            println_pipe_safe(&pretty)?;
             Ok(ExitStatus::Success)
         }
         Err(HeadError::BucketNotFound) | Err(HeadError::NotFound) => {

--- a/src/util_bin/cli/head_object.rs
+++ b/src/util_bin/cli/head_object.rs
@@ -5,6 +5,7 @@
 //              `HeadError::NotFound` (api::head_object only checks
 //              `is_not_found()`, so any 404 is `NotFound` regardless of
 //              whether the bucket or the key is missing).
+//              Report println made pipe-safe (ported from s3util-rs 1.9.2).
 
 use anyhow::Result;
 
@@ -12,6 +13,8 @@ use s3util_rs::config::ClientConfig;
 use s3util_rs::config::args::head_object::HeadObjectArgs;
 use s3util_rs::output::json::head_object_to_json;
 use s3util_rs::storage::s3::api::{self, HeadError, HeadObjectOpts};
+
+use crate::pipe_safe::println_pipe_safe;
 
 use super::ExitStatus;
 
@@ -45,7 +48,7 @@ pub async fn run_head_object(
         Ok(out) => {
             let json = head_object_to_json(&out);
             let pretty = serde_json::to_string_pretty(&json)?;
-            println!("{pretty}");
+            println_pipe_safe(&pretty)?;
             Ok(ExitStatus::Success)
         }
         Err(HeadError::BucketNotFound | HeadError::NotFound) => {

--- a/src/util_bin/cli/indicator.rs
+++ b/src/util_bin/cli/indicator.rs
@@ -1,6 +1,10 @@
 // Vendored from s3util-rs@1.0.0 (commit 4edffac51939d78b33aae9476ed61be9df1b35c0)
 //   src/bin/s3util/cli/indicator.rs
 // Adjustments: stripped #[cfg(test)] mod tests
+//              Result lines to stderr made best-effort (ported from
+//              s3util-rs 1.9.2 — eprintln! panics on a closed stderr).
+
+use std::io::Write;
 
 use async_channel::Receiver;
 use indicatif::{HumanBytes, ProgressBar, ProgressDrawTarget, ProgressStyle};
@@ -132,7 +136,10 @@ pub fn show_indicator(
                     progress_text.finish_and_clear();
 
                     if show_result && total_error_count == 0 {
-                        eprintln!("-> {resolved_target}");
+                        // eprintln! panics when stderr is a closed pipe
+                        // (`s7cmd cp ... 2>&1 | head`); result lines are
+                        // best-effort, like the tracing PipeSafeWriter.
+                        let _ = writeln!(std::io::stderr(), "-> {resolved_target}");
 
                         let mut parts = vec![format!(
                             "Transferred: {} | {}/sec",
@@ -150,7 +157,7 @@ pub fn show_indicator(
                         parts.push(format!("additional checksum verify: {checksum_status}"));
 
                         let result_message = parts.join(", ");
-                        eprintln!("{result_message}");
+                        let _ = writeln!(std::io::stderr(), "{result_message}");
                     }
 
                     return;

--- a/src/util_bin/cli/list_object_annotations.rs
+++ b/src/util_bin/cli/list_object_annotations.rs
@@ -1,6 +1,8 @@
 // Vendored from s3util-rs@1.6.0
 //   src/bin/s3util/cli/list_object_annotations.rs
-// Adjustments: none — the upstream file already targets `super::ExitStatus`.
+// Adjustments: none beyond the note below — the upstream file already
+//              targets `super::ExitStatus`.
+//              Report println made pipe-safe (ported from s3util-rs 1.9.2).
 
 use anyhow::Result;
 
@@ -8,6 +10,8 @@ use s3util_rs::config::ClientConfig;
 use s3util_rs::config::args::list_object_annotations::ListObjectAnnotationsArgs;
 use s3util_rs::output::json::list_object_annotations_to_json;
 use s3util_rs::storage::s3::api::{self, HeadError, ListObjectAnnotationsParams};
+
+use crate::pipe_safe::println_pipe_safe;
 
 use super::ExitStatus;
 
@@ -42,7 +46,7 @@ pub async fn run_list_object_annotations(
         Ok(out) => {
             let json = list_object_annotations_to_json(&out);
             let pretty = serde_json::to_string_pretty(&json)?;
-            println!("{pretty}");
+            println_pipe_safe(&pretty)?;
             Ok(ExitStatus::Success)
         }
         Err(HeadError::BucketNotFound) => {

--- a/src/util_bin/cli/presign.rs
+++ b/src/util_bin/cli/presign.rs
@@ -1,6 +1,7 @@
 // Vendored from s3util-rs@1.4.0
 //   src/bin/s3util/cli/presign.rs
 // Adjustments: rewrote crate::cli → super.
+//              Report println made pipe-safe (ported from s3util-rs 1.9.2).
 
 use std::time::Duration;
 
@@ -9,6 +10,8 @@ use anyhow::Result;
 use s3util_rs::config::ClientConfig;
 use s3util_rs::config::args::presign::PresignArgs;
 use s3util_rs::storage::s3::api;
+
+use crate::pipe_safe::println_pipe_safe;
 
 use super::ExitStatus;
 
@@ -32,6 +35,6 @@ pub async fn run_presign(args: PresignArgs, client_config: ClientConfig) -> Resu
         client_config.request_payer.clone(),
     )
     .await?;
-    println!("{url}");
+    println_pipe_safe(&url)?;
     Ok(ExitStatus::Success)
 }

--- a/src/util_bin/cli/put_object_annotation.rs
+++ b/src/util_bin/cli/put_object_annotation.rs
@@ -1,6 +1,8 @@
 // Vendored from s3util-rs@1.6.0
 //   src/bin/s3util/cli/put_object_annotation.rs
-// Adjustments: none — the upstream file already targets `super::ExitStatus`.
+// Adjustments: none beyond the note below — the upstream file already
+//              targets `super::ExitStatus`.
+//              Report println made pipe-safe (ported from s3util-rs 1.9.2).
 
 use anyhow::{Context, Result};
 use aws_sdk_s3::primitives::ByteStream;
@@ -11,6 +13,8 @@ use s3util_rs::config::args::put_object_annotation::PutObjectAnnotationArgs;
 use s3util_rs::output::json::put_object_annotation_to_json;
 use s3util_rs::storage::annotation;
 use s3util_rs::storage::s3::api::{self, HeadError, PutObjectAnnotationParams};
+
+use crate::pipe_safe::println_pipe_safe;
 
 use super::ExitStatus;
 
@@ -91,7 +95,7 @@ pub async fn run_put_object_annotation(
         Ok(out) => {
             annotation::verify_crc64nvme(&crc64, out.checksum_crc64_nvme())?;
             let json = put_object_annotation_to_json(&out);
-            println!("{}", serde_json::to_string_pretty(&json)?);
+            println_pipe_safe(&serde_json::to_string_pretty(&json)?)?;
             info!(
                 bucket = %bucket,
                 key = %key,

--- a/tests/cli_broken_pipe.rs
+++ b/tests/cli_broken_pipe.rs
@@ -1,0 +1,241 @@
+//! Process-level broken-pipe regression tests. No AWS access is needed:
+//! completions, help, and version never leave the process, presign signs
+//! locally with dummy static credentials, the batch-run script is empty,
+//! and the get-bucket-versioning report comes from a loopback
+//! [`MockS3Server`].
+//!
+//! Each test hands the child a stdout (or stderr) whose read end is already
+//! closed, so every write to it fails with `BrokenPipe` from the first
+//! byte — the worst case of piping to a consumer that exits without
+//! reading, such as `s7cmd --auto-complete-shell bash | head 1` (`head`
+//! treats `1` as a file name, fails to open it, and never reads its input)
+//! or `head -1`/`grep -q`/a pager closed early. The binary must exit
+//! through its normal paths: never panic ("failed printing to stdout:
+//! Broken pipe" / "failed to write completion file") and never die of
+//! SIGPIPE (which would surface here as `status.code() == None`).
+//!
+//! The tracing-writer counterpart (`PipeSafeWriter` on a closed stderr
+//! during offline-failing commands) is pinned by `cli_closed_stderr.rs`.
+
+mod common;
+
+use common::{MockResponse, MockS3Server, mock_target_args, s7cmd_cmd_clean_env};
+use std::process::{Command, Stdio};
+
+/// Run `cmd` with a pre-closed stdout pipe and return (exit_code, stderr).
+fn run_with_closed_stdout(cmd: &mut Command) -> (Option<i32>, String) {
+    let (reader, writer) = std::io::pipe().expect("failed to create pipe");
+    // Close the read end before the child even starts: with no readers left,
+    // every stdout write in the child fails with EPIPE immediately.
+    drop(reader);
+
+    let output = cmd
+        .stdin(Stdio::null())
+        .stdout(Stdio::from(writer))
+        .stderr(Stdio::piped())
+        .output()
+        .expect("failed to spawn s7cmd binary");
+    (
+        output.status.code(),
+        String::from_utf8_lossy(&output.stderr).to_string(),
+    )
+}
+
+/// Run `cmd` with pre-closed stdout AND stderr pipes; only the exit code is
+/// observable. This is the `s7cmd ... 2>&1 | head 1` case, where both
+/// streams share one pipe whose reader is already gone.
+fn run_with_closed_stdout_and_stderr(cmd: &mut Command) -> Option<i32> {
+    let (out_reader, out_writer) = std::io::pipe().expect("failed to create pipe");
+    let (err_reader, err_writer) = std::io::pipe().expect("failed to create pipe");
+    drop(out_reader);
+    drop(err_reader);
+
+    cmd.stdin(Stdio::null())
+        .stdout(Stdio::from(out_writer))
+        .stderr(Stdio::from(err_writer))
+        .status()
+        .expect("failed to spawn s7cmd binary")
+        .code()
+}
+
+fn assert_exits_zero_without_panic(code: Option<i32>, stderr: &str, what: &str) {
+    assert!(
+        !stderr.contains("panicked"),
+        "{what} must not panic on a closed stdout pipe; stderr: {stderr}"
+    );
+    assert_eq!(
+        code,
+        Some(0),
+        "{what} must exit 0 on a closed stdout pipe (None = killed by \
+         SIGPIPE); stderr: {stderr}"
+    );
+}
+
+/// Completion scripts are rendered to a buffer and written pipe-safely —
+/// clap_complete itself would panic ("failed to write completion file") if
+/// its generator wrote straight into a closed stdout.
+#[test]
+fn completion_script_with_closed_stdout_exits_zero() {
+    for shell in ["bash", "zsh", "fish", "powershell", "elvish"] {
+        let (code, stderr) =
+            run_with_closed_stdout(s7cmd_cmd_clean_env().args(["--auto-complete-shell", shell]));
+        assert_exits_zero_without_panic(code, &stderr, &format!("--auto-complete-shell {shell}"));
+    }
+}
+
+/// The completion script must still be emitted in full when stdout is
+/// actually read — the pipe-safe path only swallows a vanished reader, it
+/// must not swallow the output itself.
+#[test]
+fn completion_script_still_prints_when_read() {
+    let output = s7cmd_cmd_clean_env()
+        .args(["--auto-complete-shell", "bash"])
+        .output()
+        .expect("failed to spawn s7cmd binary");
+
+    assert!(output.status.success(), "expected exit 0");
+    let script = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        script.contains("_s7cmd"),
+        "expected bash completion function in output, got: {script:?}"
+    );
+}
+
+/// `presign` prints its URL through `pipe_safe::println_pipe_safe` — the
+/// same helper every JSON-report subcommand (get-bucket-versioning,
+/// head-object, ...) uses — so this pins the fix for the reported
+/// `get-bucket-versioning ... | head 1` panic without needing AWS.
+/// Credentials are the AWS documentation example values passed as flags;
+/// presign resolves them locally and signs without network I/O.
+#[test]
+fn presign_with_closed_stdout_exits_zero() {
+    let mut cmd = s7cmd_cmd_clean_env();
+    cmd.args([
+        "presign",
+        "--target-access-key",
+        "AKIAIOSFODNN7EXAMPLE",
+        "--target-secret-access-key",
+        "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+        "--target-region",
+        "us-east-1",
+        "s3://closed-stdout-test-bucket/test-key",
+    ])
+    // Keep the developer's real AWS setup out of the credential chain.
+    .env("AWS_EC2_METADATA_DISABLED", "true")
+    .env("AWS_CONFIG_FILE", "/nonexistent/aws-config")
+    .env(
+        "AWS_SHARED_CREDENTIALS_FILE",
+        "/nonexistent/aws-credentials",
+    )
+    .env_remove("AWS_ACCESS_KEY_ID")
+    .env_remove("AWS_SECRET_ACCESS_KEY")
+    .env_remove("AWS_SESSION_TOKEN");
+    let (code, stderr) = run_with_closed_stdout(&mut cmd);
+    assert_exits_zero_without_panic(code, &stderr, "presign");
+}
+
+/// The versioning XML the AWS SDK parses into a non-empty report, so the
+/// subcommand reaches its `println_pipe_safe` call (an empty config is
+/// logged, not printed).
+const VERSIONING_ENABLED_XML: &str = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n\
+     <VersioningConfiguration xmlns=\"http://s3.amazonaws.com/doc/2006-03-01/\">\
+     <Status>Enabled</Status></VersioningConfiguration>";
+
+fn get_bucket_versioning_cmd(server: &MockS3Server) -> Command {
+    let mut cmd = s7cmd_cmd_clean_env();
+    cmd.arg("get-bucket-versioning")
+        .args(mock_target_args(&server.endpoint_url()))
+        .arg("s3://mock-bucket");
+    cmd
+}
+
+/// The originally reported panic, end to end without AWS:
+/// `s7cmd get-bucket-versioning s3://bucket | head 1` — the mock endpoint
+/// returns a real versioning config, and the JSON report is printed into a
+/// stdout whose reader is already gone. The S3 call has succeeded by then,
+/// so the command must exit 0, not panic with
+/// `failed printing to stdout: Broken pipe`.
+#[test]
+fn get_bucket_versioning_report_with_closed_stdout_exits_zero() {
+    let server = MockS3Server::start(vec![MockResponse::new(200, VERSIONING_ENABLED_XML)]);
+    let (code, stderr) = run_with_closed_stdout(&mut get_bucket_versioning_cmd(&server));
+    assert_exits_zero_without_panic(code, &stderr, "get-bucket-versioning");
+}
+
+/// Counterpart with a read stdout: the report must still be emitted in
+/// full — the pipe-safe path only swallows a vanished reader, never the
+/// report itself.
+#[test]
+fn get_bucket_versioning_report_still_prints_when_read() {
+    let server = MockS3Server::start(vec![MockResponse::new(200, VERSIONING_ENABLED_XML)]);
+    let (code, stdout, stderr) = common::run(&mut get_bucket_versioning_cmd(&server));
+    assert_eq!(code, Some(0), "expected exit 0; stderr: {stderr}");
+    assert!(
+        stdout.contains("\"Status\"") && stdout.contains("Enabled"),
+        "expected the versioning JSON report on stdout, got: {stdout:?}"
+    );
+}
+
+/// Help and --version are printed by clap, whose `Error::exit` swallows
+/// write errors ("Swallow broken pipe errors" in clap itself). Pinned here
+/// so a clap regression would be caught.
+#[test]
+fn help_and_version_with_closed_stdout_exit_zero() {
+    let (code, stderr) = run_with_closed_stdout(s7cmd_cmd_clean_env().arg("--help"));
+    assert_exits_zero_without_panic(code, &stderr, "--help");
+
+    let (code, stderr) =
+        run_with_closed_stdout(s7cmd_cmd_clean_env().args(["get-bucket-versioning", "--help"]));
+    assert_exits_zero_without_panic(code, &stderr, "get-bucket-versioning --help");
+
+    let (code, stderr) = run_with_closed_stdout(s7cmd_cmd_clean_env().arg("--version"));
+    assert_exits_zero_without_panic(code, &stderr, "--version");
+}
+
+/// The batch-run summary is written to stderr after the run completes. With
+/// stderr a closed pipe that `eprintln!` panicked, turning an otherwise
+/// clean run into exit 101 — even though every line had already executed.
+/// The summary is now best-effort: an empty script (stdin at EOF) must
+/// still exit 0 with both output pipes closed.
+#[test]
+fn batch_run_summary_with_closed_stderr_exits_zero() {
+    let code = run_with_closed_stdout_and_stderr(s7cmd_cmd_clean_env().args(["batch-run", "-"]));
+    assert_eq!(
+        code,
+        Some(0),
+        "an empty batch-run with closed output pipes must exit 0 \
+         (101 = the summary line panicked, None = killed by SIGPIPE)"
+    );
+}
+
+/// Same as above with `--json-tracing`, which routes the summary through
+/// `format_json` but down the identical stderr write.
+#[test]
+fn batch_run_json_summary_with_closed_stderr_exits_zero() {
+    let code = run_with_closed_stdout_and_stderr(s7cmd_cmd_clean_env().args([
+        "batch-run",
+        "--json-tracing",
+        "-",
+    ]));
+    assert_eq!(
+        code,
+        Some(0),
+        "an empty batch-run --json-tracing with closed output pipes must \
+         exit 0 (101 = the summary line panicked, None = killed by SIGPIPE)"
+    );
+}
+
+/// Config errors are reported via `clap::Error::raw(...).print()` with the
+/// result ignored, so a closed stderr must not change the exit code: an
+/// invalid clean target must still exit 2, not panic or die of SIGPIPE.
+#[test]
+fn clean_config_error_with_closed_stderr_still_exits_two() {
+    let code =
+        run_with_closed_stdout_and_stderr(s7cmd_cmd_clean_env().args(["clean", "s3:///prefix"]));
+    assert_eq!(
+        code,
+        Some(2),
+        "an invalid clean target with closed output pipes must still exit 2 \
+         (None = killed by SIGPIPE, 101 = panicked)"
+    );
+}


### PR DESCRIPTION
## Contributing

- Bug reports are welcome, but responses are not guaranteed.
- Since this project is considered functionally complete, I will not accept any feature requests.
- If you find this project useful, feel free to fork and modify it as you wish.

🔒 I consider this project “complete” and will maintain it only minimally going forward.
However, I intend to keep the AWS SDK for Rust and other dependencies up to date monthly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved command-line output when results are piped to tools that stop reading early.
  * Reports, completion scripts, transfer output, and batch summaries now exit cleanly when output pipes close.
  * Other output failures still report errors, and truncated object downloads continue to fail appropriately.

* **Documentation**
  * Clarified performance expectations, request-rate limits, rate-limiting options, and S3-compatible storage limitations.

* **Release**
  * Updated the application to version 1.7.2.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->