### PR TITLE
Exit with code 130 when sync, ls, or clean is interrupted by Ctrl+C (SIGINT)

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -223,7 +223,7 @@ jobs:
       attestations: write
     strategy:
       matrix:
-        os: [ macos-latest, windows-latest ]
+        os: [ macos-latest, windows-latest, windows-11-arm ]
         include:
           - os: macos-latest
             artifact_suffix: macos-aarch64
@@ -232,6 +232,10 @@ jobs:
           - os: windows-latest
             artifact_suffix: windows-x86_64
             target: x86_64-pc-windows-msvc
+            file_extension: ".exe"
+          - os: windows-11-arm
+            artifact_suffix: windows-aarch64
+            target: aarch64-pc-windows-msvc
             file_extension: ".exe"
     steps:
       - name: install rust toolchain

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,7 @@ jobs:
           - stable
         os:
           - windows-latest
+          - windows-11-arm
           - macos-latest
         include:
           - os: ubuntu-latest
@@ -33,6 +34,8 @@ jobs:
             target: aarch64-unknown-linux-musl
           - os: windows-latest
             target: x86_64-pc-windows-msvc
+          - os: windows-11-arm
+            target: aarch64-pc-windows-msvc
           - os: macos-latest
             target: aarch64-apple-darwin
     runs-on: ${{ matrix.os }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,13 +8,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [1.8.0] - 2026-08-07
 
 Bug-fix release, taken as a minor version because the fix changes an observable exit code. No library pins move;
-the fix lands in s7cmd's vendored command frontends.
+the fix lands in s7cmd's vendored command frontends. Pre-built binaries for Windows on ARM return with this
+release (see **Added**).
 
 **Upgrade notes:**
 
 - [Breaking change] `sync`, `ls`, and `clean` runs interrupted by Ctrl+C (SIGINT) now exit with code `130` instead
   of `0`. Scripts and automation that test the exit status should treat `130` as user interruption rather than
   success.
+
+### Added
+
+- Pre-built binaries for Windows on ARM (`aarch64-pc-windows-msvc`). The `windows-11-arm` runner is restored to CI
+  (build and test) and to the release workflow, which now publishes a `windows-aarch64` artifact alongside the
+  existing platforms. The runner had been dropped in 0.1.1 while the `LNK1322` (Cortex-A53 erratum #843419) build
+  failure was unresolved; that failure no longer occurs.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.8.0] - 2026-08-07
+## [1.8.0] - 2026-08-08
 
-Bug-fix release, taken as a minor version because the fix changes an observable exit code. No library pins move;
-the fix lands in s7cmd's vendored command frontends. Pre-built binaries for Windows on ARM return with this
+Bug-fix release, taken as a minor version because the fix changes an observable exit code. All four underlying
+libraries shipped the same SIGINT exit-code fix upstream, and their pins move to those releases (see **Changed**);
+the fix also lands in s7cmd's vendored command frontends. Pre-built binaries for Windows on ARM return with this
 release (see **Added**).
 
 **Upgrade notes:**
@@ -37,6 +38,15 @@ release (see **Added**).
   deletion errors no longer exits 0. Uninterrupted runs are unchanged, and so is `clean`'s confirmation prompt,
   where Ctrl+C still terminates the process immediately through the default OS handler. 
 
+#### cp / mv
+
+- A `cp`/`mv` interrupted by Ctrl+C (SIGINT) now always exits with code 130. Most interrupted runs already did,
+  but when the forced shutdown itself surfaced a non-cancellation error — for example a body read that failed
+  only after the signal arrived — the run was misreported as a transfer failure (`copy failed.`, exit 1). Ctrl+C
+  now takes precedence over any error produced by the shutdown it triggered (ported from s3util-rs 1.10.0).
+  Uninterrupted runs are unaffected, a worker failure that cancels the pipeline without a SIGINT is still
+  reported as a failure (exit 1), and an interrupted `mv` still never deletes the source object.
+
 #### batch-run
 
 - A Ctrl+C'd `sync`, `ls`, or `clean` line inside a batch is now bucketed `skipped (exit 130)` — matching `cp` and
@@ -44,13 +54,25 @@ release (see **Added**).
   the process, so batch-run itself keeps running exactly as before; the batch exit code follows the existing
   severity ranking, under which an interrupted batch with no other failures exits 130.
 
+### Changed
+
+- s3sync `v1.61.2 -> v1.62.0`
+- s3util-rs `v1.9.2 -> v1.10.0`
+- s3rm-rs `v1.5.2 -> v1.6.0`
+- s3ls-rs `v1.2.2 -> v1.3.0`
+
+These are the upstream releases of the same SIGINT exit-code fix: s3rm-rs 1.6.0 and s3ls-rs 1.3.0 ship the fix
+the vendored frontends port, s3sync 1.62.0 adopts the same fix for its standalone binary (it landed in s7cmd
+first), and the s3util-rs 1.10.0 `cp`/`mv` interruption-precedence fix is ported into the vendored frontend
+here.
+
 ### Underlying libraries
 
 ```toml
-s3sync = "=1.61.2"
-s3util-rs = "=1.9.2"
-s3rm-rs = "=1.5.2"
-s3ls-rs = "=1.2.2"
+s3sync = "=1.62.0"
+s3util-rs = "=1.10.0"
+s3rm-rs = "=1.6.0"
+s3ls-rs = "=1.3.0"
 ```
 
 ## [1.7.2] - 2026-08-04

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,9 +14,11 @@ release (see **Added**).
 
 **Upgrade notes:**
 
-- [Breaking change] `sync`, `ls`, and `clean` runs interrupted by Ctrl+C (SIGINT) now exit with code `130` instead
-  of `0`. Scripts and automation that test the exit status should treat `130` as user interruption rather than
-  success.
+- [Breaking change] `sync`, `ls`, and `clean` runs interrupted by Ctrl+C (SIGINT) now exit with code `130`.
+  Previously an interrupted `ls` or `clean` exited `0`, and an interrupted `sync` exited `0`, `1`, or `3`
+  depending on what the aborted run had recorded. Scripts and automation that test the exit status should treat
+  `130` as user interruption rather than success — and, for `sync`, no longer expect an interrupted run to
+  surface as `1` or `3`.
 
 ### Added
 
@@ -30,8 +32,9 @@ release (see **Added**).
 #### sync / ls / clean
 
 - [Breaking change] A run interrupted by Ctrl+C (SIGINT) now exits with code 130 (128 + SIGINT, the conventional
-  shell encoding for termination by signal) instead of 0. Previously an interrupted run was indistinguishable from
-  a successful one by its exit code, and the interruption exit code was inconsistent across subcommands (`cp` and
+  shell encoding for termination by signal). Previously an interrupted `ls` or `clean` exited 0 —
+  indistinguishable from a successful run — while an interrupted `sync` exited 0, 1, or 3 depending on what the
+  aborted shutdown had recorded, and the interruption exit code was inconsistent across subcommands (`cp` and
   `mv` already exited 130). The Ctrl+C handler records the signal in a process-global flag before cancelling the
   pipeline, and the frontend checks it once the pipeline has stopped — the interruption takes precedence over
   whatever the forced shutdown recorded, so in particular a Ctrl+C'd `clean` that had already collected genuine
@@ -50,9 +53,11 @@ release (see **Added**).
 #### batch-run
 
 - A Ctrl+C'd `sync`, `ls`, or `clean` line inside a batch is now bucketed `skipped (exit 130)` — matching `cp` and
-  `mv` — where it was previously bucketed `succeeded`. The engines return the interruption code instead of exiting
-  the process, so batch-run itself keeps running exactly as before; the batch exit code follows the existing
-  severity ranking, under which an interrupted batch with no other failures exits 130.
+  `mv` — where it was previously bucketed by whatever exit code the interrupted run happened to produce:
+  `succeeded` for `ls`, `clean`, and most `sync` lines, but `failures` or `warnings` for a `sync` whose aborted
+  shutdown had recorded errors or warnings. The engines return the interruption code instead of exiting the
+  process, so batch-run itself keeps running exactly as before; the batch exit code follows the existing severity
+  ranking, under which an interrupted batch with no other failures exits 130.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,46 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.8.0] - 2026-08-07
+
+Bug-fix release, taken as a minor version because the fix changes an observable exit code. No library pins move;
+the fix lands in s7cmd's vendored command frontends.
+
+**Upgrade notes:**
+
+- [Breaking change] `sync`, `ls`, and `clean` runs interrupted by Ctrl+C (SIGINT) now exit with code `130` instead
+  of `0`. Scripts and automation that test the exit status should treat `130` as user interruption rather than
+  success.
+
+### Fixed
+
+#### sync / ls / clean
+
+- [Breaking change] A run interrupted by Ctrl+C (SIGINT) now exits with code 130 (128 + SIGINT, the conventional
+  shell encoding for termination by signal) instead of 0. Previously an interrupted run was indistinguishable from
+  a successful one by its exit code, and the interruption exit code was inconsistent across subcommands (`cp` and
+  `mv` already exited 130). The Ctrl+C handler records the signal in a process-global flag before cancelling the
+  pipeline, and the frontend checks it once the pipeline has stopped — the interruption takes precedence over
+  whatever the forced shutdown recorded, so in particular a Ctrl+C'd `clean` that had already collected genuine
+  deletion errors no longer exits 0. Uninterrupted runs are unchanged, and so is `clean`'s confirmation prompt,
+  where Ctrl+C still terminates the process immediately through the default OS handler. 
+
+#### batch-run
+
+- A Ctrl+C'd `sync`, `ls`, or `clean` line inside a batch is now bucketed `skipped (exit 130)` — matching `cp` and
+  `mv` — where it was previously bucketed `succeeded`. The engines return the interruption code instead of exiting
+  the process, so batch-run itself keeps running exactly as before; the batch exit code follows the existing
+  severity ranking, under which an interrupted batch with no other failures exits 130.
+
+### Underlying libraries
+
+```toml
+s3sync = "=1.61.2"
+s3util-rs = "=1.9.2"
+s3rm-rs = "=1.5.2"
+s3ls-rs = "=1.2.2"
+```
+
 ## [1.7.2] - 2026-08-04
 
 Bug-fix release. Writing to a pipe whose reader has already exited crashed s7cmd on several output paths — piping to

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3051,7 +3051,7 @@ dependencies = [
 
 [[package]]
 name = "s7cmd"
-version = "1.7.2"
+version = "1.8.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2852,9 +2852,9 @@ checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "s3ls-rs"
-version = "1.2.2"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a85ed2b4b885cd62716c87f08b8d9d4fdcaa6aaf0a784cda25cc828337615d5"
+checksum = "65721d6f2abda3abb8afcba1c1021633fde91ebb80fadd35f9aee773b4bb58f2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2888,9 +2888,9 @@ dependencies = [
 
 [[package]]
 name = "s3rm-rs"
-version = "1.5.2"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f031dbfd066a66e25872e4058ae90715926754d15ca4c0c676d77b3451a01c0"
+checksum = "3aab909140f3df6cb688e570867ec7134d33adcb66c8a4d4dc535a059aead9b6"
 dependencies = [
  "anyhow",
  "async-channel",
@@ -2930,9 +2930,9 @@ dependencies = [
 
 [[package]]
 name = "s3sync"
-version = "1.61.2"
+version = "1.62.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4eb0db3ebc89239ef047457d36922a94ecc2d3ed6450cdc1cf3bfebb655fefb"
+checksum = "19e2ceea80e6ec18f324cfa4aaf7dcdc87c1ce8b92a6fdc6222d7c8b86494bb7"
 dependencies = [
  "anyhow",
  "async-channel",
@@ -2992,9 +2992,9 @@ dependencies = [
 
 [[package]]
 name = "s3util-rs"
-version = "1.9.2"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c9d549afb12b3ef8f70113354cffe26b2bb4e7ff700cdd991fbc597a2931ea6"
+checksum = "73e25a461d1669c5c0da79366b623c48440aa9d448a993fa5884b7cfcc0aa69d"
 dependencies = [
  "anyhow",
  "async-channel",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "s7cmd"
-version = "1.7.2"
+version = "1.8.0"
 edition = "2024"
 rust-version = "1.94.1"
 license = "Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,11 +16,11 @@ categories = ["command-line-utilities", "filesystem"]
 # s3sync's `lua_support` is in its default features; Lua flags
 # (--filter-callback-lua-script, etc.) automatically appear under
 # `s7cmd sync --help`. Use default-features = false to opt out.
-s3sync     = "=1.61.2"
-s3util-rs  = "=1.9.2"
+s3sync     = "=1.62.0"
+s3util-rs  = "=1.10.0"
 # Vendored bin code is sourced from these versions; pin minor.
-s3rm-rs    = "=1.5.2"
-s3ls-rs    = "=1.2.2"
+s3rm-rs    = "=1.6.0"
+s3ls-rs    = "=1.3.0"
 
 # Build-info for `s7cmd --version` (gated behind the `version` feature).
 shadow-rs = { version = "2", optional = true, default-features = false }
@@ -66,7 +66,7 @@ dyn-clone    = "1.0"
 serde_json   = "1"
 # Used by the vendored get-object-annotation runner to write the downloaded
 # payload to a temp file and atomically rename it into place. Pinned to the
-# same minor s3util-rs 1.9.0 vendors so the dep tree stays unified.
+# same minor s3util-rs 1.10.0 vendors so the dep tree stays unified.
 tempfile     = "3"
 
 [features]
@@ -83,7 +83,7 @@ uuid = { version = "1", features = ["v4"] }
 # tempfile is a regular dependency (see [dependencies]); it is therefore also
 # available to tests without a separate dev-dependency entry.
 # Used by the vendored get_object_annotation.rs unit tests to recompute the
-# MD5 an AES256 object's ETag encodes. Same minor s3util-rs 1.9.0 vendors.
+# MD5 an AES256 object's ETag encodes. Same minor s3util-rs 1.10.0 vendors.
 md5 = "0.8"
 # Used by mv.rs unit tests to implement a fake `StorageTrait` for the
 # source-delete decision tree. Already a transitive dep via s3util-rs;

--- a/README.md
+++ b/README.md
@@ -444,6 +444,23 @@ library. For details on flags, semantics, and exit codes, refer to:
 Each of these projects (except `batch-run`) also ships its own
 standalone binary, which can be used independently of s7cmd.
 
+**Exit code on interruption (v1.8.0+).** Every subcommand that catches
+Ctrl-C (SIGINT) for graceful shutdown — `sync`, `ls`, `clean`, `cp`,
+and `mv` — exits with code `130` (128 + SIGINT, the conventional shell
+encoding for termination by signal) when interrupted, and the
+interruption takes precedence over any errors or warnings the aborted
+run had recorded. This is one place s7cmd can differ from the upstream
+documentation linked above: the vendored frontends carry this fix
+ahead of the pinned s3rm-rs / s3ls-rs versions and apply the same
+behavior to `sync`, whose standalone upstream binary currently exits
+`0` on interruption. Subcommands that finish in a single API call
+install no handler, so Ctrl-C terminates them through the default
+signal disposition — which shells also report as `130`. At `clean`'s
+confirmation prompt, Ctrl-C likewise terminates immediately via the
+default handler. Inside `batch-run`, an interrupted line is bucketed
+`skipped (exit 130)` and the batch exit code follows the severity
+ranking described in the `batch-run` section above.
+
 ## Security assumptions
 
 s7cmd is built on a fundamental security assumption: **both the object storage system and the specific bucket you

--- a/README.md
+++ b/README.md
@@ -449,11 +449,13 @@ Ctrl-C (SIGINT) for graceful shutdown — `sync`, `ls`, `clean`, `cp`,
 and `mv` — exits with code `130` (128 + SIGINT, the conventional shell
 encoding for termination by signal) when interrupted, and the
 interruption takes precedence over any errors or warnings the aborted
-run had recorded. This is one place s7cmd can differ from the upstream
-documentation linked above: the vendored frontends carry this fix
-ahead of the pinned s3rm-rs / s3ls-rs versions and apply the same
-behavior to `sync`, whose standalone upstream binary currently exits
-`0` on interruption. Subcommands that finish in a single API call
+run had recorded. The pinned library releases ship the same behavior
+in their standalone binaries (s3sync 1.62.0, s3util-rs 1.10.0,
+s3rm-rs 1.6.0, s3ls-rs 1.3.0), so s7cmd and the upstream tools now
+agree on interruption exit codes; the vendored frontends differ only
+in returning the code instead of calling `process::exit`, so
+`batch-run` survives an interrupted line. Subcommands that finish in a
+single API call
 install no handler, so Ctrl-C terminates them through the default
 signal disposition — which shells also report as `130`. At `clean`'s
 confirmation prompt, Ctrl-C likewise terminates immediately via the

--- a/src/batch_run/executor.rs
+++ b/src/batch_run/executor.rs
@@ -407,6 +407,15 @@ pub async fn run_parallel(
                     break;
                 }
                 let permit = sem.clone().acquire_owned().await.expect("sem closed");
+                // Re-check after the await: a SIGINT that landed while this
+                // loop was parked on the semaphore must not dispatch one more
+                // line — that line's freshly installed Ctrl+C handler would
+                // never see the already-delivered signal, so it would run to
+                // full completion yet read the process-global interruption
+                // state stored by a sibling line and misreport as skipped.
+                if interrupt.load(Ordering::SeqCst) {
+                    break;
+                }
                 let dispatch = Arc::clone(&dispatch);
                 let progress = Arc::clone(&progress);
                 let fail_cancel = Arc::clone(&fail_cancel);
@@ -554,6 +563,18 @@ pub async fn run_parallel_streaming(
                 };
 
                 let permit = sem.clone().acquire_owned().await.expect("sem closed");
+                // Re-check after the awaits: a SIGINT that landed while this
+                // loop was parked on `rx.recv()` or the semaphore must not
+                // dispatch one more line — that line's freshly installed
+                // Ctrl+C handler would never see the already-delivered
+                // signal, so it would run to full completion yet read the
+                // process-global interruption state stored by a sibling line
+                // and misreport as skipped. The line pulled above never
+                // spawns; count it skipped like the post-loop drain does.
+                if interrupt.load(Ordering::SeqCst) {
+                    summary.skipped += 1;
+                    break;
+                }
                 let dispatch = Arc::clone(&dispatch);
                 let progress = Arc::clone(&progress);
                 let fail_cancel = Arc::clone(&fail_cancel);

--- a/src/clean_bin/ctrl_c_handler.rs
+++ b/src/clean_bin/ctrl_c_handler.rs
@@ -1,16 +1,35 @@
 // Vendored from s3rm-rs@1.3.3
 //   src/bin/s3rm/ctrl_c_handler/mod.rs
 // Adjustments: flattened from ctrl_c_handler/mod.rs to ctrl_c_handler.rs;
-//              stripped #[cfg(test)] mod tests
+//              stripped #[cfg(test)] mod tests;
+//              CTRL_C_RECEIVED flag / is_ctrl_c_received() ported from
+//              s3rm-rs@1.6.0 (nidor1998/s3rm-rs#100) so mod.rs can exit
+//              130 on SIGINT; tests serialize through the process-wide
+//              crate::signal_test_lock instead of a per-module semaphore
+//              (s7cmd has four ctrl_c_handler test modules in one test
+//              binary, and a SIGINT sent by one is broadcast to all).
 
 // Ctrl+C signal handler adapted from s3sync's `bin/s3sync/cli/ctrl_c_handler/mod.rs`.
 //
 // Uses tokio::select! to wait for either pipeline cancellation or Ctrl+C signal.
 
+use std::sync::atomic::{AtomicBool, Ordering};
+
 use s3rm_rs::PipelineCancellationToken;
 use tokio::task::JoinHandle;
 use tokio::{select, signal};
 use tracing::{debug, error};
+
+static CTRL_C_RECEIVED: AtomicBool = AtomicBool::new(false);
+
+/// Whether a Ctrl+C (SIGINT) signal has been received by the handler.
+///
+/// The flag is stored before the cancellation token is cancelled, so any
+/// code that observes the pipeline stopping due to cancellation is
+/// guaranteed to see `true` here when Ctrl+C was the cause.
+pub fn is_ctrl_c_received() -> bool {
+    CTRL_C_RECEIVED.load(Ordering::SeqCst)
+}
 
 pub fn spawn_ctrl_c_handler(cancellation_token: PipelineCancellationToken) -> JoinHandle<()> {
     tokio::spawn(async move {
@@ -22,6 +41,7 @@ pub fn spawn_ctrl_c_handler(cancellation_token: PipelineCancellationToken) -> Jo
                 match result {
                     Ok(()) => {
                         debug!("ctrl-c received, shutting down.");
+                        CTRL_C_RECEIVED.store(true, Ordering::SeqCst);
                         cancellation_token.cancel();
                     }
                     Err(e) => {
@@ -35,18 +55,22 @@ pub fn spawn_ctrl_c_handler(cancellation_token: PipelineCancellationToken) -> Jo
 
 #[cfg(test)]
 mod tests {
-    use std::sync::{Arc, OnceLock};
-
+    use crate::signal_test_lock::semaphore;
     use s3rm_rs::create_pipeline_cancellation_token;
-    use tokio::sync::Semaphore;
 
     use super::*;
 
-    fn semaphore() -> Arc<Semaphore> {
-        static SEMAPHORE: OnceLock<Arc<Semaphore>> = OnceLock::new();
-        SEMAPHORE
-            .get_or_init(|| Arc::new(Semaphore::new(1)))
-            .clone()
+    /// The flag is process-global; tests that assert on it reset it first
+    /// (while holding the signal-test lock) so they don't start from a
+    /// `true` stored by an earlier test. The reset cannot fence stragglers:
+    /// tests that drive the full run() paths spawn handlers without holding
+    /// the lock, and an earlier lock holder's SIGINT reaches those handlers
+    /// whenever their runtime next polls them — observed >100ms late.
+    /// `true` is therefore asserted only after this test's own SIGINT,
+    /// and "not set" is concluded only after retries (each straggler
+    /// fires at most once).
+    fn reset_ctrl_c_received() {
+        CTRL_C_RECEIVED.store(false, Ordering::SeqCst);
     }
 
     #[tokio::test]
@@ -78,5 +102,86 @@ mod tests {
 
         join_handle.await.unwrap();
         assert!(cancellation_token.is_cancelled());
+    }
+
+    #[tokio::test]
+    #[cfg(target_family = "unix")]
+    async fn ctrl_c_received_flag_is_set_on_sigint() {
+        const STARTUP_MS: u64 = 100;
+
+        let _permit = semaphore().acquire_owned().await.unwrap();
+        reset_ctrl_c_received();
+
+        let cancellation_token = create_pipeline_cancellation_token();
+        let join_handle = spawn_ctrl_c_handler(cancellation_token.clone());
+        tokio::time::sleep(std::time::Duration::from_millis(STARTUP_MS)).await;
+
+        // No `!is_ctrl_c_received()` check before the kill: a straggler
+        // delivery of an earlier test's SIGINT can land inside the startup
+        // sleep above (see reset_ctrl_c_received), so "still false here"
+        // is not guaranteed. Only the true-direction below is stable.
+
+        nix::sys::signal::kill(nix::unistd::Pid::this(), nix::sys::signal::Signal::SIGINT).unwrap();
+
+        join_handle.await.unwrap();
+
+        assert!(is_ctrl_c_received());
+        assert!(cancellation_token.is_cancelled());
+    }
+
+    /// The flag must already be visible when the token cancellation becomes
+    /// observable — mod.rs relies on this ordering to decide the exit code
+    /// after the pipeline stops.
+    #[tokio::test]
+    #[cfg(target_family = "unix")]
+    async fn ctrl_c_received_flag_is_visible_once_token_is_cancelled() {
+        const STARTUP_MS: u64 = 100;
+
+        let _permit = semaphore().acquire_owned().await.unwrap();
+        reset_ctrl_c_received();
+
+        let cancellation_token = create_pipeline_cancellation_token();
+        let join_handle = spawn_ctrl_c_handler(cancellation_token.clone());
+        tokio::time::sleep(std::time::Duration::from_millis(STARTUP_MS)).await;
+
+        nix::sys::signal::kill(nix::unistd::Pid::this(), nix::sys::signal::Signal::SIGINT).unwrap();
+
+        cancellation_token.cancelled().await;
+        assert!(is_ctrl_c_received());
+
+        join_handle.await.unwrap();
+    }
+
+    /// The handler's cancellation arm must not store the flag. A single
+    /// observation can be contaminated by a straggler SIGINT delivery from
+    /// an earlier test (see reset_ctrl_c_received), and each straggler
+    /// fires at most once — so retry and require only that some attempt
+    /// completes with the flag still clear. A regression (storing on the
+    /// cancellation arm) sets the flag on every attempt and still fails.
+    #[tokio::test]
+    async fn ctrl_c_received_flag_is_not_set_on_token_cancellation() {
+        const ATTEMPTS: usize = 5;
+
+        let _permit = semaphore().acquire_owned().await.unwrap();
+
+        for attempt in 1..=ATTEMPTS {
+            reset_ctrl_c_received();
+
+            let cancellation_token = create_pipeline_cancellation_token();
+
+            let join_handle = spawn_ctrl_c_handler(cancellation_token.clone());
+            cancellation_token.cancel();
+
+            join_handle.await.unwrap();
+
+            if !is_ctrl_c_received() {
+                return;
+            }
+            eprintln!("straggler SIGINT contaminated attempt {attempt}/{ATTEMPTS}; retrying");
+        }
+        panic!(
+            "token cancellation must not set CTRL_C_RECEIVED \
+             (flag was set on all {ATTEMPTS} attempts)"
+        );
     }
 }

--- a/src/clean_bin/mod.rs
+++ b/src/clean_bin/mod.rs
@@ -13,6 +13,11 @@
 //              from batch-run without killing the process mid-batch).
 //              "Deletion cancelled." made EPIPE-safe (a bare eprintln!
 //              panics when stderr is a closed pipe).
+//              SIGINT exit code 130 ported from s3rm-rs@1.6.0
+//              (nidor1998/s3rm-rs#100): after the pipeline stops, a run
+//              interrupted by Ctrl+C returns 130 instead of falling
+//              through to the success/error mapping — returned rather
+//              than upstream's std::process::exit so batch-run survives.
 
 use std::io::Write;
 
@@ -32,6 +37,10 @@ pub mod ui_config;
 pub const EXIT_CODE_SUCCESS: i32 = 0;
 pub const EXIT_CODE_WARNING: i32 = 3;
 pub const EXIT_CODE_ABNORMAL_TERMINATION: i32 = 101;
+/// Conventional exit code for termination by Ctrl+C: 128 + SIGINT(2), the
+/// shell encoding that lets scripts distinguish user interruption from
+/// real failures.
+const SIGINT_EXIT_CODE: i32 = 130;
 
 pub fn start_tracing_if_necessary(config: &Config) -> bool {
     if let Some(tracing_config) = config.tracing_config.as_ref() {
@@ -94,6 +103,16 @@ pub async fn run(config: Config) -> Result<i32> {
         }
 
         let duration_sec = format!("{:.3}", start_time.elapsed().as_secs_f32());
+
+        // Ctrl+C takes precedence over whatever the pipeline recorded: once
+        // SIGINT is received the run is "interrupted", even if the forced
+        // shutdown also surfaced errors or warnings. Returned (not
+        // process::exit as upstream does) so batch-run survives and buckets
+        // the line as skipped.
+        if ctrl_c_handler::is_ctrl_c_received() {
+            debug!(duration_sec = duration_sec, "deletion cancelled by user.");
+            return Ok(SIGINT_EXIT_CODE);
+        }
 
         if pipeline.has_error() {
             if pipeline.has_panic() {
@@ -162,6 +181,20 @@ mod tests {
         ]);
         assert!(config.tracing_config.is_none());
         assert!(!start_tracing_if_necessary(&config));
+    }
+
+    #[test]
+    fn sigint_exit_code_is_130() {
+        assert_eq!(SIGINT_EXIT_CODE, 130);
+    }
+
+    #[test]
+    #[cfg(target_family = "unix")]
+    fn sigint_exit_code_follows_128_plus_signal_number_convention() {
+        assert_eq!(
+            SIGINT_EXIT_CODE,
+            128 + nix::sys::signal::Signal::SIGINT as i32
+        );
     }
 
     // NOTE: a "no --force, non-TTY → SafetyChecker errors out" test would be

--- a/src/ls_bin/ctrl_c_handler.rs
+++ b/src/ls_bin/ctrl_c_handler.rs
@@ -3,7 +3,8 @@
 // Adjustments: flattened from ctrl_c_handler/mod.rs to ctrl_c_handler.rs;
 //              stripped #[cfg(test)] mod tests;
 //              CTRL_C_RECEIVED flag / is_ctrl_c_received() ported from
-//              nidor1998/s3ls-rs#34 so mod.rs can exit 130 on SIGINT;
+//              s3ls-rs@1.3.0 (nidor1998/s3ls-rs#34) so mod.rs can exit
+//              130 on SIGINT;
 //              tests serialize through the process-wide
 //              crate::signal_test_lock instead of a per-module semaphore
 //              (s7cmd has four ctrl_c_handler test modules in one test

--- a/src/ls_bin/ctrl_c_handler.rs
+++ b/src/ls_bin/ctrl_c_handler.rs
@@ -1,16 +1,35 @@
 // Vendored from s3ls-rs@0.4.1
 //   src/bin/s3ls/ctrl_c_handler/mod.rs
 // Adjustments: flattened from ctrl_c_handler/mod.rs to ctrl_c_handler.rs;
-//              stripped #[cfg(test)] mod tests
+//              stripped #[cfg(test)] mod tests;
+//              CTRL_C_RECEIVED flag / is_ctrl_c_received() ported from
+//              nidor1998/s3ls-rs#34 so mod.rs can exit 130 on SIGINT;
+//              tests serialize through the process-wide
+//              crate::signal_test_lock instead of a per-module semaphore
+//              (s7cmd has four ctrl_c_handler test modules in one test
+//              binary, and a SIGINT sent by one is broadcast to all).
 
 // Ctrl+C signal handler adapted from s3sync's `bin/s3sync/cli/ctrl_c_handler/mod.rs`.
 //
 // Uses tokio::select! to wait for either pipeline cancellation or Ctrl+C signal.
 
+use std::sync::atomic::{AtomicBool, Ordering};
+
 use s3ls_rs::PipelineCancellationToken;
 use tokio::task::JoinHandle;
 use tokio::{select, signal};
 use tracing::{debug, error};
+
+static CTRL_C_RECEIVED: AtomicBool = AtomicBool::new(false);
+
+/// Whether a Ctrl+C (SIGINT) signal has been received by the handler.
+///
+/// The flag is stored before the cancellation token is cancelled, so any
+/// code that observes the pipeline stopping due to cancellation is
+/// guaranteed to see `true` here when Ctrl+C was the cause.
+pub fn is_ctrl_c_received() -> bool {
+    CTRL_C_RECEIVED.load(Ordering::SeqCst)
+}
 
 pub fn spawn_ctrl_c_handler(cancellation_token: PipelineCancellationToken) -> JoinHandle<()> {
     tokio::spawn(async move {
@@ -22,6 +41,7 @@ pub fn spawn_ctrl_c_handler(cancellation_token: PipelineCancellationToken) -> Jo
                 match result {
                     Ok(()) => {
                         debug!("ctrl-c received, shutting down.");
+                        CTRL_C_RECEIVED.store(true, Ordering::SeqCst);
                         cancellation_token.cancel();
                     }
                     Err(e) => {
@@ -35,18 +55,22 @@ pub fn spawn_ctrl_c_handler(cancellation_token: PipelineCancellationToken) -> Jo
 
 #[cfg(test)]
 mod tests {
-    use std::sync::{Arc, OnceLock};
-
+    use crate::signal_test_lock::semaphore;
     use s3ls_rs::create_pipeline_cancellation_token;
-    use tokio::sync::Semaphore;
 
     use super::*;
 
-    fn semaphore() -> Arc<Semaphore> {
-        static SEMAPHORE: OnceLock<Arc<Semaphore>> = OnceLock::new();
-        SEMAPHORE
-            .get_or_init(|| Arc::new(Semaphore::new(1)))
-            .clone()
+    /// The flag is process-global; tests that assert on it reset it first
+    /// (while holding the signal-test lock) so they don't start from a
+    /// `true` stored by an earlier test. The reset cannot fence stragglers:
+    /// tests that drive the full run() paths spawn handlers without holding
+    /// the lock, and an earlier lock holder's SIGINT reaches those handlers
+    /// whenever their runtime next polls them — observed >100ms late.
+    /// `true` is therefore asserted only after this test's own SIGINT,
+    /// and "not set" is concluded only after retries (each straggler
+    /// fires at most once).
+    fn reset_ctrl_c_received() {
+        CTRL_C_RECEIVED.store(false, Ordering::SeqCst);
     }
 
     #[tokio::test]
@@ -76,5 +100,86 @@ mod tests {
 
         join_handle.await.unwrap();
         assert!(cancellation_token.is_cancelled());
+    }
+
+    #[tokio::test]
+    #[cfg(target_family = "unix")]
+    async fn ctrl_c_received_flag_is_set_on_sigint() {
+        const STARTUP_MS: u64 = 100;
+
+        let _permit = semaphore().acquire_owned().await.unwrap();
+        reset_ctrl_c_received();
+
+        let cancellation_token = create_pipeline_cancellation_token();
+        let join_handle = spawn_ctrl_c_handler(cancellation_token.clone());
+        tokio::time::sleep(std::time::Duration::from_millis(STARTUP_MS)).await;
+
+        // No `!is_ctrl_c_received()` check before the kill: a straggler
+        // delivery of an earlier test's SIGINT can land inside the startup
+        // sleep above (see reset_ctrl_c_received), so "still false here"
+        // is not guaranteed. Only the true-direction below is stable.
+
+        nix::sys::signal::kill(nix::unistd::Pid::this(), nix::sys::signal::Signal::SIGINT).unwrap();
+
+        join_handle.await.unwrap();
+
+        assert!(is_ctrl_c_received());
+        assert!(cancellation_token.is_cancelled());
+    }
+
+    /// The flag must already be visible when the token cancellation becomes
+    /// observable — mod.rs relies on this ordering to decide the exit code
+    /// after the pipeline stops.
+    #[tokio::test]
+    #[cfg(target_family = "unix")]
+    async fn ctrl_c_received_flag_is_visible_once_token_is_cancelled() {
+        const STARTUP_MS: u64 = 100;
+
+        let _permit = semaphore().acquire_owned().await.unwrap();
+        reset_ctrl_c_received();
+
+        let cancellation_token = create_pipeline_cancellation_token();
+        let join_handle = spawn_ctrl_c_handler(cancellation_token.clone());
+        tokio::time::sleep(std::time::Duration::from_millis(STARTUP_MS)).await;
+
+        nix::sys::signal::kill(nix::unistd::Pid::this(), nix::sys::signal::Signal::SIGINT).unwrap();
+
+        cancellation_token.cancelled().await;
+        assert!(is_ctrl_c_received());
+
+        join_handle.await.unwrap();
+    }
+
+    /// The handler's cancellation arm must not store the flag. A single
+    /// observation can be contaminated by a straggler SIGINT delivery from
+    /// an earlier test (see reset_ctrl_c_received), and each straggler
+    /// fires at most once — so retry and require only that some attempt
+    /// completes with the flag still clear. A regression (storing on the
+    /// cancellation arm) sets the flag on every attempt and still fails.
+    #[tokio::test]
+    async fn ctrl_c_received_flag_is_not_set_on_token_cancellation() {
+        const ATTEMPTS: usize = 5;
+
+        let _permit = semaphore().acquire_owned().await.unwrap();
+
+        for attempt in 1..=ATTEMPTS {
+            reset_ctrl_c_received();
+
+            let cancellation_token = create_pipeline_cancellation_token();
+
+            let join_handle = spawn_ctrl_c_handler(cancellation_token.clone());
+            cancellation_token.cancel();
+
+            join_handle.await.unwrap();
+
+            if !is_ctrl_c_received() {
+                return;
+            }
+            eprintln!("straggler SIGINT contaminated attempt {attempt}/{ATTEMPTS}; retrying");
+        }
+        panic!(
+            "token cancellation must not set CTRL_C_RECEIVED \
+             (flag was set on all {ATTEMPTS} attempts)"
+        );
     }
 }

--- a/src/ls_bin/mod.rs
+++ b/src/ls_bin/mod.rs
@@ -10,6 +10,11 @@
 //              on Err instead. run() now returns Result<i32> instead of
 //              calling std::process::exit (so it can be invoked from
 //              batch-run without killing the process mid-batch).
+//              SIGINT exit code 130 ported from nidor1998/s3ls-rs#34:
+//              after the pipeline stops, a run interrupted by Ctrl+C
+//              returns 130 instead of falling through to the
+//              success/error mapping — returned rather than upstream's
+//              std::process::exit so batch-run survives.
 
 use anyhow::Result;
 use tracing::{debug, error};
@@ -22,6 +27,11 @@ use s3ls_rs::{
 
 mod ctrl_c_handler;
 mod tracing_init;
+
+/// Conventional exit code for termination by Ctrl+C: 128 + SIGINT(2), the
+/// shell encoding that lets scripts distinguish user interruption from
+/// real failures.
+const SIGINT_EXIT_CODE: i32 = 130;
 
 pub fn start_tracing_if_necessary(config: &Config) -> bool {
     if let Some(tracing_config) = config.tracing_config.as_ref() {
@@ -58,7 +68,19 @@ pub async fn run(config: Config) -> Result<i32> {
 
     let pipeline = ListingPipeline::new(config, cancellation_token);
 
-    match pipeline.run().await {
+    let result = pipeline.run().await;
+
+    // Ctrl+C takes precedence over whatever the pipeline returned: once
+    // SIGINT is received the run is "interrupted", even if the shutdown
+    // also surfaced an error. Returned (not process::exit as upstream
+    // does) so batch-run survives and buckets the line as skipped.
+    if ctrl_c_handler::is_ctrl_c_received() {
+        let duration_sec = format!("{:.3}", start_time.elapsed().as_secs_f32());
+        debug!(duration_sec = duration_sec, "listing cancelled by user.");
+        return Ok(SIGINT_EXIT_CODE);
+    }
+
+    match result {
         Ok(()) => {
             let duration_sec = format!("{:.3}", start_time.elapsed().as_secs_f32());
             debug!(duration_sec = duration_sec, "s7cmd ls has been completed.");
@@ -105,6 +127,20 @@ mod tests {
         let config = build_config(&["s3ls", "-qqq", "--target-profile", "p", "s3://test-bucket"]);
         assert!(config.tracing_config.is_none());
         assert!(!start_tracing_if_necessary(&config));
+    }
+
+    #[test]
+    fn sigint_exit_code_is_130() {
+        assert_eq!(SIGINT_EXIT_CODE, 130);
+    }
+
+    #[test]
+    #[cfg(target_family = "unix")]
+    fn sigint_exit_code_follows_128_plus_signal_number_convention() {
+        assert_eq!(
+            SIGINT_EXIT_CODE,
+            128 + nix::sys::signal::Signal::SIGINT as i32
+        );
     }
 
     /// Bucket-listing mode (no target prefix) against an unreachable endpoint.

--- a/src/ls_bin/mod.rs
+++ b/src/ls_bin/mod.rs
@@ -10,11 +10,11 @@
 //              on Err instead. run() now returns Result<i32> instead of
 //              calling std::process::exit (so it can be invoked from
 //              batch-run without killing the process mid-batch).
-//              SIGINT exit code 130 ported from nidor1998/s3ls-rs#34:
-//              after the pipeline stops, a run interrupted by Ctrl+C
-//              returns 130 instead of falling through to the
-//              success/error mapping — returned rather than upstream's
-//              std::process::exit so batch-run survives.
+//              SIGINT exit code 130 ported from s3ls-rs@1.3.0
+//              (nidor1998/s3ls-rs#34): after the pipeline stops, a run
+//              interrupted by Ctrl+C returns 130 instead of falling
+//              through to the success/error mapping — returned rather
+//              than upstream's std::process::exit so batch-run survives.
 
 use anyhow::Result;
 use tracing::{debug, error};

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,6 +18,40 @@ mod util_bin;
 
 use cli::{Cli, Cmd, cli_command};
 
+/// Serializes every unit test that delivers SIGINT to the test process or
+/// asserts on a Ctrl+C-received flag.
+///
+/// The four vendored `ctrl_c_handler` test modules (sync_bin, ls_bin,
+/// clean_bin, util_bin) all run inside one test binary, and a SIGINT sent
+/// to the process by one module's test is broadcast to every live tokio
+/// signal listener. A per-module semaphore cannot prevent one module's
+/// SIGINT from tripping another module's in-flight handler, which would
+/// make the `CTRL_C_RECEIVED`-flag assertions flaky — so all of them
+/// share this single process-wide lock instead.
+///
+/// The lock only serializes the tests that hold it. Tests that drive the
+/// full run() paths (sync_bin / ls_bin / clean_bin `run()`, `dispatch`)
+/// spawn ctrl-c handlers without holding it, and a lock holder's SIGINT
+/// is broadcast to those handlers too — each stores its module's
+/// `CTRL_C_RECEIVED` flag whenever its own runtime next polls it, which
+/// can be long after the lock has moved on to another test. Flag tests
+/// therefore assert only the true-direction after their own SIGINT, and
+/// establish "not set" via retries; see `reset_ctrl_c_received` in the
+/// ctrl_c_handler test modules.
+#[cfg(test)]
+pub(crate) mod signal_test_lock {
+    use std::sync::{Arc, OnceLock};
+
+    use tokio::sync::Semaphore;
+
+    pub(crate) fn semaphore() -> Arc<Semaphore> {
+        static SEMAPHORE: OnceLock<Arc<Semaphore>> = OnceLock::new();
+        SEMAPHORE
+            .get_or_init(|| Arc::new(Semaphore::new(1)))
+            .clone()
+    }
+}
+
 #[tokio::main]
 async fn main() -> ExitCode {
     let cli_args = match Cli::from_arg_matches(&cli_command().get_matches()) {

--- a/src/sync_bin/cli/ctrl_c_handler.rs
+++ b/src/sync_bin/cli/ctrl_c_handler.rs
@@ -1,12 +1,33 @@
 // Vendored from s3sync@1.57.1
 //   src/bin/s3sync/cli/ctrl_c_handler/mod.rs
-// Adjustments: stripped #[cfg(test)] mod tests
+// Adjustments: stripped #[cfg(test)] mod tests;
+//              CTRL_C_RECEIVED flag / is_ctrl_c_received() added so
+//              mod.rs can exit 130 on SIGINT — an s7cmd addition (not in
+//              upstream s3sync as of 1.61.2), same pattern as the fix
+//              ported from nidor1998/s3rm-rs#100 / nidor1998/s3ls-rs#34;
+//              tests serialize through the process-wide
+//              crate::signal_test_lock instead of a per-module semaphore
+//              (s7cmd has four ctrl_c_handler test modules in one test
+//              binary, and a SIGINT sent by one is broadcast to all).
+
+use std::sync::atomic::{AtomicBool, Ordering};
 
 use tokio::task::JoinHandle;
 use tokio::{select, signal};
 use tracing::{debug, error, warn};
 
 use s3sync::types::token::PipelineCancellationToken;
+
+static CTRL_C_RECEIVED: AtomicBool = AtomicBool::new(false);
+
+/// Whether a Ctrl+C (SIGINT) signal has been received by the handler.
+///
+/// The flag is stored before the cancellation token is cancelled, so any
+/// code that observes the pipeline stopping due to cancellation is
+/// guaranteed to see `true` here when Ctrl+C was the cause.
+pub fn is_ctrl_c_received() -> bool {
+    CTRL_C_RECEIVED.load(Ordering::SeqCst)
+}
 
 pub fn spawn_ctrl_c_handler(cancellation_token: PipelineCancellationToken) -> JoinHandle<()> {
     tokio::spawn(async move {
@@ -18,6 +39,7 @@ pub fn spawn_ctrl_c_handler(cancellation_token: PipelineCancellationToken) -> Jo
                 match result {
                     Ok(()) => {
                         warn!("ctrl-c received, shutting down.");
+                        CTRL_C_RECEIVED.store(true, Ordering::SeqCst);
                         cancellation_token.cancel();
                     }
                     Err(e) => {
@@ -31,18 +53,22 @@ pub fn spawn_ctrl_c_handler(cancellation_token: PipelineCancellationToken) -> Jo
 
 #[cfg(test)]
 mod tests {
-    use std::sync::{Arc, OnceLock};
-
+    use crate::signal_test_lock::semaphore;
     use s3sync::types::token::create_pipeline_cancellation_token;
-    use tokio::sync::Semaphore;
 
     use super::*;
 
-    fn semaphore() -> Arc<Semaphore> {
-        static SEMAPHORE: OnceLock<Arc<Semaphore>> = OnceLock::new();
-        SEMAPHORE
-            .get_or_init(|| Arc::new(Semaphore::new(1)))
-            .clone()
+    /// The flag is process-global; tests that assert on it reset it first
+    /// (while holding the signal-test lock) so they don't start from a
+    /// `true` stored by an earlier test. The reset cannot fence stragglers:
+    /// tests that drive the full run() paths spawn handlers without holding
+    /// the lock, and an earlier lock holder's SIGINT reaches those handlers
+    /// whenever their runtime next polls them — observed >100ms late.
+    /// `true` is therefore asserted only after this test's own SIGINT,
+    /// and "not set" is concluded only after retries (each straggler
+    /// fires at most once).
+    fn reset_ctrl_c_received() {
+        CTRL_C_RECEIVED.store(false, Ordering::SeqCst);
     }
 
     #[tokio::test]
@@ -72,5 +98,86 @@ mod tests {
 
         join_handle.await.unwrap();
         assert!(cancellation_token.is_cancelled());
+    }
+
+    #[tokio::test]
+    #[cfg(target_family = "unix")]
+    async fn ctrl_c_received_flag_is_set_on_sigint() {
+        const STARTUP_MS: u64 = 100;
+
+        let _permit = semaphore().acquire_owned().await.unwrap();
+        reset_ctrl_c_received();
+
+        let cancellation_token = create_pipeline_cancellation_token();
+        let join_handle = spawn_ctrl_c_handler(cancellation_token.clone());
+        tokio::time::sleep(std::time::Duration::from_millis(STARTUP_MS)).await;
+
+        // No `!is_ctrl_c_received()` check before the kill: a straggler
+        // delivery of an earlier test's SIGINT can land inside the startup
+        // sleep above (see reset_ctrl_c_received), so "still false here"
+        // is not guaranteed. Only the true-direction below is stable.
+
+        nix::sys::signal::kill(nix::unistd::Pid::this(), nix::sys::signal::Signal::SIGINT).unwrap();
+
+        join_handle.await.unwrap();
+
+        assert!(is_ctrl_c_received());
+        assert!(cancellation_token.is_cancelled());
+    }
+
+    /// The flag must already be visible when the token cancellation becomes
+    /// observable — mod.rs relies on this ordering to decide the exit code
+    /// after the pipeline stops.
+    #[tokio::test]
+    #[cfg(target_family = "unix")]
+    async fn ctrl_c_received_flag_is_visible_once_token_is_cancelled() {
+        const STARTUP_MS: u64 = 100;
+
+        let _permit = semaphore().acquire_owned().await.unwrap();
+        reset_ctrl_c_received();
+
+        let cancellation_token = create_pipeline_cancellation_token();
+        let join_handle = spawn_ctrl_c_handler(cancellation_token.clone());
+        tokio::time::sleep(std::time::Duration::from_millis(STARTUP_MS)).await;
+
+        nix::sys::signal::kill(nix::unistd::Pid::this(), nix::sys::signal::Signal::SIGINT).unwrap();
+
+        cancellation_token.cancelled().await;
+        assert!(is_ctrl_c_received());
+
+        join_handle.await.unwrap();
+    }
+
+    /// The handler's cancellation arm must not store the flag. A single
+    /// observation can be contaminated by a straggler SIGINT delivery from
+    /// an earlier test (see reset_ctrl_c_received), and each straggler
+    /// fires at most once — so retry and require only that some attempt
+    /// completes with the flag still clear. A regression (storing on the
+    /// cancellation arm) sets the flag on every attempt and still fails.
+    #[tokio::test]
+    async fn ctrl_c_received_flag_is_not_set_on_token_cancellation() {
+        const ATTEMPTS: usize = 5;
+
+        let _permit = semaphore().acquire_owned().await.unwrap();
+
+        for attempt in 1..=ATTEMPTS {
+            reset_ctrl_c_received();
+
+            let cancellation_token = create_pipeline_cancellation_token();
+
+            let join_handle = spawn_ctrl_c_handler(cancellation_token.clone());
+            cancellation_token.cancel();
+
+            join_handle.await.unwrap();
+
+            if !is_ctrl_c_received() {
+                return;
+            }
+            eprintln!("straggler SIGINT contaminated attempt {attempt}/{ATTEMPTS}; retrying");
+        }
+        panic!(
+            "token cancellation must not set CTRL_C_RECEIVED \
+             (flag was set on all {ATTEMPTS} attempts)"
+        );
     }
 }

--- a/src/sync_bin/cli/ctrl_c_handler.rs
+++ b/src/sync_bin/cli/ctrl_c_handler.rs
@@ -2,9 +2,9 @@
 //   src/bin/s3sync/cli/ctrl_c_handler/mod.rs
 // Adjustments: stripped #[cfg(test)] mod tests;
 //              CTRL_C_RECEIVED flag / is_ctrl_c_received() added so
-//              mod.rs can exit 130 on SIGINT — an s7cmd addition (not in
-//              upstream s3sync as of 1.61.2), same pattern as the fix
-//              ported from nidor1998/s3rm-rs#100 / nidor1998/s3ls-rs#34;
+//              mod.rs can exit 130 on SIGINT — landed in s7cmd first and
+//              adopted by upstream s3sync in 1.62.0, same pattern as the
+//              fix from s3rm-rs@1.6.0 / s3ls-rs@1.3.0;
 //              tests serialize through the process-wide
 //              crate::signal_test_lock instead of a per-module semaphore
 //              (s7cmd has four ctrl_c_handler test modules in one test

--- a/src/sync_bin/cli/mod.rs
+++ b/src/sync_bin/cli/mod.rs
@@ -8,9 +8,11 @@
 //              annotation_mismatch fields added in s3sync 1.59.0.
 //              SIGINT exit code 130 added: after the pipeline stops, a
 //              run interrupted by Ctrl+C returns 130 instead of falling
-//              through to the success/error mapping — an s7cmd addition
-//              (not in upstream s3sync as of 1.61.2), same pattern as
-//              nidor1998/s3rm-rs#100 / nidor1998/s3ls-rs#34.
+//              through to the success/error mapping — landed in s7cmd
+//              first and adopted by upstream s3sync in 1.62.0 (which
+//              calls std::process::exit; s7cmd returns the code so
+//              batch-run survives), same pattern as s3rm-rs@1.6.0 /
+//              s3ls-rs@1.3.0.
 
 use anyhow::{Result, anyhow};
 use s3sync::Config;

--- a/src/sync_bin/cli/mod.rs
+++ b/src/sync_bin/cli/mod.rs
@@ -6,6 +6,11 @@
 //              batch-run without killing the process mid-batch);
 //              show_sync_report_summary() carries the annotation_matches /
 //              annotation_mismatch fields added in s3sync 1.59.0.
+//              SIGINT exit code 130 added: after the pipeline stops, a
+//              run interrupted by Ctrl+C returns 130 instead of falling
+//              through to the success/error mapping — an s7cmd addition
+//              (not in upstream s3sync as of 1.61.2), same pattern as
+//              nidor1998/s3rm-rs#100 / nidor1998/s3ls-rs#34.
 
 use anyhow::{Result, anyhow};
 use s3sync::Config;
@@ -26,6 +31,10 @@ const EXIT_CODE_ERROR: i32 = 1;
 #[allow(dead_code)]
 const EXIT_CODE_INVALID_ARGS: i32 = 2;
 const EXIT_CODE_WARNING: i32 = 3;
+/// Conventional exit code for termination by Ctrl+C: 128 + SIGINT(2), the
+/// shell encoding that lets scripts distinguish user interruption from
+/// real failures.
+const SIGINT_EXIT_CODE: i32 = 130;
 
 pub async fn run(config: Config) -> Result<i32> {
     #[allow(unused_assignments)]
@@ -61,6 +70,17 @@ pub async fn run(config: Config) -> Result<i32> {
         indicator_join_handle.await?;
 
         let duration_sec = format!("{:.3}", start_time.elapsed().as_secs_f32());
+
+        // Ctrl+C takes precedence over whatever the pipeline recorded: once
+        // SIGINT is received the run is "interrupted", even if the forced
+        // shutdown also surfaced errors or warnings. Returned (not
+        // process::exit) so batch-run survives and buckets the line as
+        // skipped.
+        if ctrl_c_handler::is_ctrl_c_received() {
+            debug!(duration_sec = duration_sec, "sync cancelled by user.");
+            return Ok(SIGINT_EXIT_CODE);
+        }
+
         if pipeline.has_error() {
             error!(duration_sec = duration_sec, "s7cmd sync failed.");
 
@@ -137,6 +157,20 @@ mod tests {
         fn drop(&mut self) {
             let _ = std::fs::remove_dir_all(&self.0);
         }
+    }
+
+    #[test]
+    fn sigint_exit_code_is_130() {
+        assert_eq!(SIGINT_EXIT_CODE, 130);
+    }
+
+    #[test]
+    #[cfg(target_family = "unix")]
+    fn sigint_exit_code_follows_128_plus_signal_number_convention() {
+        assert_eq!(
+            SIGINT_EXIT_CODE,
+            128 + nix::sys::signal::Signal::SIGINT as i32
+        );
     }
 
     #[test]

--- a/src/util_bin/cli/ctrl_c_handler.rs
+++ b/src/util_bin/cli/ctrl_c_handler.rs
@@ -1,16 +1,33 @@
 // Vendored from s3util-rs@0.2.0
 //   src/bin/s3util/cli/ctrl_c_handler.rs
 // Adjustments: stripped #[cfg(test)] mod tests;
+//              CTRL_C_RECEIVED flag / is_ctrl_c_received() ported from
+//              s3util-rs@1.10.0 so run_copy_phase can report a Ctrl+C'd
+//              cp/mv as a cancellation (exit 130) even when the forced
+//              shutdown surfaced a non-cancellation error;
 //              tests serialize through the process-wide
 //              crate::signal_test_lock instead of a per-module semaphore
 //              (s7cmd has four ctrl_c_handler test modules in one test
 //              binary, and a SIGINT sent by one is broadcast to all).
+
+use std::sync::atomic::{AtomicBool, Ordering};
 
 use tokio::task::JoinHandle;
 use tokio::{select, signal};
 use tracing::{debug, error, warn};
 
 use s3util_rs::types::token::PipelineCancellationToken;
+
+static CTRL_C_RECEIVED: AtomicBool = AtomicBool::new(false);
+
+/// Whether a Ctrl+C (SIGINT) signal has been received by the handler.
+///
+/// The flag is stored before the cancellation token is cancelled, so any
+/// code that observes the pipeline stopping due to cancellation is
+/// guaranteed to see `true` here when Ctrl+C was the cause.
+pub fn is_ctrl_c_received() -> bool {
+    CTRL_C_RECEIVED.load(Ordering::SeqCst)
+}
 
 pub fn spawn_ctrl_c_handler(cancellation_token: PipelineCancellationToken) -> JoinHandle<()> {
     tokio::spawn(async move {
@@ -22,6 +39,7 @@ pub fn spawn_ctrl_c_handler(cancellation_token: PipelineCancellationToken) -> Jo
                 match result {
                     Ok(()) => {
                         warn!("ctrl-c received, shutting down.");
+                        CTRL_C_RECEIVED.store(true, Ordering::SeqCst);
                         cancellation_token.cancel();
                     }
                     Err(e) => {
@@ -39,6 +57,19 @@ mod tests {
     use s3util_rs::types::token::create_pipeline_cancellation_token;
 
     use super::*;
+
+    /// The flag is process-global; tests that assert on it reset it first
+    /// (while holding the signal-test lock) so they don't start from a
+    /// `true` stored by an earlier test. The reset cannot fence stragglers:
+    /// tests that drive the full run() paths spawn handlers without holding
+    /// the lock, and an earlier lock holder's SIGINT reaches those handlers
+    /// whenever their runtime next polls them — observed >100ms late.
+    /// `true` is therefore asserted only after this test's own SIGINT,
+    /// and "not set" is concluded only after retries (each straggler
+    /// fires at most once).
+    fn reset_ctrl_c_received() {
+        CTRL_C_RECEIVED.store(false, Ordering::SeqCst);
+    }
 
     #[tokio::test]
     async fn ctrl_c_handler_handles_cancellation_token() {
@@ -67,5 +98,86 @@ mod tests {
 
         join_handle.await.unwrap();
         assert!(cancellation_token.is_cancelled());
+    }
+
+    #[tokio::test]
+    #[cfg(target_family = "unix")]
+    async fn ctrl_c_received_flag_is_set_on_sigint() {
+        const STARTUP_MS: u64 = 100;
+
+        let _permit = semaphore().acquire_owned().await.unwrap();
+        reset_ctrl_c_received();
+
+        let cancellation_token = create_pipeline_cancellation_token();
+        let join_handle = spawn_ctrl_c_handler(cancellation_token.clone());
+        tokio::time::sleep(std::time::Duration::from_millis(STARTUP_MS)).await;
+
+        // No `!is_ctrl_c_received()` check before the kill: a straggler
+        // delivery of an earlier test's SIGINT can land inside the startup
+        // sleep above (see reset_ctrl_c_received), so "still false here"
+        // is not guaranteed. Only the true-direction below is stable.
+
+        nix::sys::signal::kill(nix::unistd::Pid::this(), nix::sys::signal::Signal::SIGINT).unwrap();
+
+        join_handle.await.unwrap();
+
+        assert!(is_ctrl_c_received());
+        assert!(cancellation_token.is_cancelled());
+    }
+
+    /// The flag must already be visible when the token cancellation becomes
+    /// observable — run_copy_phase relies on this ordering to decide the
+    /// exit code after the pipeline stops.
+    #[tokio::test]
+    #[cfg(target_family = "unix")]
+    async fn ctrl_c_received_flag_is_visible_once_token_is_cancelled() {
+        const STARTUP_MS: u64 = 100;
+
+        let _permit = semaphore().acquire_owned().await.unwrap();
+        reset_ctrl_c_received();
+
+        let cancellation_token = create_pipeline_cancellation_token();
+        let join_handle = spawn_ctrl_c_handler(cancellation_token.clone());
+        tokio::time::sleep(std::time::Duration::from_millis(STARTUP_MS)).await;
+
+        nix::sys::signal::kill(nix::unistd::Pid::this(), nix::sys::signal::Signal::SIGINT).unwrap();
+
+        cancellation_token.cancelled().await;
+        assert!(is_ctrl_c_received());
+
+        join_handle.await.unwrap();
+    }
+
+    /// The handler's cancellation arm must not store the flag. A single
+    /// observation can be contaminated by a straggler SIGINT delivery from
+    /// an earlier test (see reset_ctrl_c_received), and each straggler
+    /// fires at most once — so retry and require only that some attempt
+    /// completes with the flag still clear. A regression (storing on the
+    /// cancellation arm) sets the flag on every attempt and still fails.
+    #[tokio::test]
+    async fn ctrl_c_received_flag_is_not_set_on_token_cancellation() {
+        const ATTEMPTS: usize = 5;
+
+        let _permit = semaphore().acquire_owned().await.unwrap();
+
+        for attempt in 1..=ATTEMPTS {
+            reset_ctrl_c_received();
+
+            let cancellation_token = create_pipeline_cancellation_token();
+
+            let join_handle = spawn_ctrl_c_handler(cancellation_token.clone());
+            cancellation_token.cancel();
+
+            join_handle.await.unwrap();
+
+            if !is_ctrl_c_received() {
+                return;
+            }
+            eprintln!("straggler SIGINT contaminated attempt {attempt}/{ATTEMPTS}; retrying");
+        }
+        panic!(
+            "token cancellation must not set CTRL_C_RECEIVED \
+             (flag was set on all {ATTEMPTS} attempts)"
+        );
     }
 }

--- a/src/util_bin/cli/ctrl_c_handler.rs
+++ b/src/util_bin/cli/ctrl_c_handler.rs
@@ -1,6 +1,10 @@
 // Vendored from s3util-rs@0.2.0
 //   src/bin/s3util/cli/ctrl_c_handler.rs
-// Adjustments: stripped #[cfg(test)] mod tests
+// Adjustments: stripped #[cfg(test)] mod tests;
+//              tests serialize through the process-wide
+//              crate::signal_test_lock instead of a per-module semaphore
+//              (s7cmd has four ctrl_c_handler test modules in one test
+//              binary, and a SIGINT sent by one is broadcast to all).
 
 use tokio::task::JoinHandle;
 use tokio::{select, signal};
@@ -31,19 +35,10 @@ pub fn spawn_ctrl_c_handler(cancellation_token: PipelineCancellationToken) -> Jo
 
 #[cfg(test)]
 mod tests {
-    use std::sync::{Arc, OnceLock};
-
+    use crate::signal_test_lock::semaphore;
     use s3util_rs::types::token::create_pipeline_cancellation_token;
-    use tokio::sync::Semaphore;
 
     use super::*;
-
-    fn semaphore() -> Arc<Semaphore> {
-        static SEMAPHORE: OnceLock<Arc<Semaphore>> = OnceLock::new();
-        SEMAPHORE
-            .get_or_init(|| Arc::new(Semaphore::new(1)))
-            .clone()
-    }
 
     #[tokio::test]
     async fn ctrl_c_handler_handles_cancellation_token() {

--- a/src/util_bin/cli/mod.rs
+++ b/src/util_bin/cli/mod.rs
@@ -8,6 +8,11 @@
 //     is reported as a failure (exit 1), not a SIGINT cancellation (exit 130);
 //   - extract_keys: a local target with a trailing '/' resolves to
 //     <dir>/<basename> on every platform (fs_util::has_trailing_separator).
+// Includes the fix from s3util-rs 1.10.0:
+//   - run_copy_phase: Ctrl+C (ctrl_c_handler::is_ctrl_c_received) takes
+//     precedence over any error the forced shutdown surfaced, so an
+//     interrupted cp/mv is reported as a cancellation (exit 130), not a
+//     transfer failure (exit 1).
 
 use std::sync::Arc;
 use std::sync::atomic::AtomicBool;
@@ -561,7 +566,13 @@ pub async fn run_copy_phase(config: Config) -> Result<CopyPhase> {
     // Wait for indicator to finish
     let _ = indicator_handle.await;
 
-    let cancelled = is_user_cancellation(cancellation_token.is_cancelled(), &transfer_result);
+    // Ctrl+C takes precedence over whatever the forced shutdown recorded:
+    // once SIGINT is received the run is "interrupted" (exit 130), even if
+    // the aborted transfer surfaced a non-cancellation error on its way
+    // down — e.g. a body read failed by stalled-stream protection while the
+    // pipeline was being torn down.
+    let cancelled = ctrl_c_handler::is_ctrl_c_received()
+        || is_user_cancellation(cancellation_token.is_cancelled(), &transfer_result);
     let has_warning = has_warning.load(std::sync::atomic::Ordering::SeqCst);
 
     Ok(CopyPhase {
@@ -586,6 +597,11 @@ pub async fn run_copy_phase(config: Config) -> Result<CopyPhase> {
 /// The transfer result is the authoritative signal: a genuine SIGINT surfaces
 /// as `S3syncError::Cancelled` (possibly wrapped in `.context()`), and anything
 /// else is a real failure that must be reported as one.
+///
+/// A genuine SIGINT is additionally recorded in a process-global flag
+/// (`ctrl_c_handler::is_ctrl_c_received`) that `run_copy_phase` consults with
+/// precedence over this decision, so a Ctrl+C whose forced shutdown surfaced a
+/// non-cancellation error is still reported as a cancellation (exit 130).
 fn is_user_cancellation(
     token_cancelled: bool,
     transfer_result: &Result<s3util_rs::transfer::TransferOutcome>,
@@ -781,6 +797,17 @@ mod tests {
         assert_eq!(EXIT_CODE_WARNING, 3);
         assert_eq!(EXIT_CODE_NOT_FOUND, 4);
         assert_eq!(EXIT_CODE_CANCELLED, 130);
+    }
+
+    /// 130 = 128 + SIGINT(2), the conventional shell encoding for a process
+    /// terminated by Ctrl+C.
+    #[test]
+    #[cfg(target_family = "unix")]
+    fn exit_code_cancelled_follows_128_plus_signal_number_convention() {
+        assert_eq!(
+            EXIT_CODE_CANCELLED,
+            128 + nix::sys::signal::Signal::SIGINT as i32
+        );
     }
 
     #[test]

--- a/src/util_bin/cli/mod.rs
+++ b/src/util_bin/cli/mod.rs
@@ -225,7 +225,11 @@ pub async fn run_copy_phase(config: Config) -> Result<CopyPhase> {
     let resolved_target_display = format_target_path(&config.target, &target_key);
 
     // Dry-run short-circuit: log the would-do action and skip the transfer,
-    // indicator, ctrl-c handler, and rate limiter.
+    // indicator, and rate limiter. The ctrl-c handler IS spawned (below),
+    // matching upstream, where dry-run flows through the full phase: the
+    // S3-to-S3 annotation listing can take real network time, and a Ctrl+C
+    // during it must be reported as a cancellation (exit 130) via the same
+    // is_ctrl_c_received() precedence as a real transfer.
     //
     // A real S3-to-S3 run also syncs the source object's annotations (that
     // logic lives in the library `transfer()` this command calls). To keep
@@ -239,6 +243,8 @@ pub async fn run_copy_phase(config: Config) -> Result<CopyPhase> {
     // delete, so whichever source_storage is handed back here is never
     // invoked for a mutation.
     if config.dry_run {
+        ctrl_c_handler::spawn_ctrl_c_handler(cancellation_token.clone());
+
         info!(
             source = %source_str,
             target = %resolved_target_display,
@@ -291,12 +297,18 @@ pub async fn run_copy_phase(config: Config) -> Result<CopyPhase> {
             (Ok(TransferOutcome::default()), placeholder_source)
         };
 
+        // Same interruption precedence as the real-transfer tail below: a
+        // Ctrl+C during the dry-run work wins over whatever error the
+        // aborted annotation listing surfaced.
+        let cancelled = ctrl_c_handler::is_ctrl_c_received()
+            || is_user_cancellation(cancellation_token.is_cancelled(), &transfer_result);
+
         return Ok(CopyPhase {
             transfer_result,
             source_storage,
             source_key,
             cancellation_token,
-            cancelled: false,
+            cancelled,
             has_warning: false,
         });
     }

--- a/tests/cli_sigint_exit_code.rs
+++ b/tests/cli_sigint_exit_code.rs
@@ -27,7 +27,7 @@ use std::io::{Read as _, Write as _};
 use std::net::{TcpListener, TcpStream};
 use std::path::PathBuf;
 use std::process::{Child, Command, Stdio};
-use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
@@ -55,6 +55,12 @@ struct FakeS3 {
     object_gets_served: Arc<AtomicUsize>,
     deletes_served: Arc<AtomicUsize>,
     deleted_keys: Arc<Mutex<Vec<String>>>,
+    annotation_pages_served: Arc<AtomicUsize>,
+    /// While false, `ListObjectAnnotations` responses carry a continuation
+    /// token (endless listing); set to true to make the next response the
+    /// final page. The annotation listing loop is deliberately
+    /// non-cancellable in the library, so tests end it from the outside.
+    finish_annotations: Arc<AtomicBool>,
 }
 
 /// Serve canned S3 responses over plain HTTP/1.1, one request per
@@ -91,11 +97,15 @@ fn spawn_fake_s3_impl(total_pages: Option<usize>, stall_object_bodies: bool) -> 
     let object_gets_served = Arc::new(AtomicUsize::new(0));
     let deletes_served = Arc::new(AtomicUsize::new(0));
     let deleted_keys = Arc::new(Mutex::new(Vec::new()));
+    let annotation_pages_served = Arc::new(AtomicUsize::new(0));
+    let finish_annotations = Arc::new(AtomicBool::new(false));
 
     let pages = Arc::clone(&pages_served);
     let gets = Arc::clone(&object_gets_served);
     let deletes = Arc::clone(&deletes_served);
     let keys = Arc::clone(&deleted_keys);
+    let annotation_pages = Arc::clone(&annotation_pages_served);
+    let finish_ann = Arc::clone(&finish_annotations);
     std::thread::spawn(move || {
         for stream in listener.incoming() {
             let Ok(mut stream) = stream else { break };
@@ -125,6 +135,8 @@ fn spawn_fake_s3_impl(total_pages: Option<usize>, stall_object_bodies: bool) -> 
                 &gets,
                 &deletes,
                 &keys,
+                &annotation_pages,
+                &finish_ann,
             );
             let _ = stream.write_all(&response);
             let _ = stream.flush();
@@ -137,6 +149,8 @@ fn spawn_fake_s3_impl(total_pages: Option<usize>, stall_object_bodies: bool) -> 
         object_gets_served,
         deletes_served,
         deleted_keys,
+        annotation_pages_served,
+        finish_annotations,
     }
 }
 
@@ -149,6 +163,7 @@ fn is_object_request(request_line: &str) -> bool {
     (method == "GET" || method == "HEAD")
         && !has_query_param(target, "versioning")
         && !has_query_param(target, "list-type")
+        && !has_query_param(target, "annotation")
 }
 
 /// Response for the stalled object: full headers advertising
@@ -221,6 +236,7 @@ fn read_request(stream: &mut TcpStream) -> Option<(String, String)> {
     Some((request_line, body))
 }
 
+#[allow(clippy::too_many_arguments)]
 fn route_request(
     request_line: &str,
     request_body: &str,
@@ -229,6 +245,8 @@ fn route_request(
     object_gets_served: &AtomicUsize,
     deletes_served: &AtomicUsize,
     deleted_keys: &Mutex<Vec<String>>,
+    annotation_pages_served: &AtomicUsize,
+    finish_annotations: &AtomicBool,
 ) -> Vec<u8> {
     let mut parts = request_line.split_whitespace();
     let method = parts.next().unwrap_or("");
@@ -239,6 +257,16 @@ fn route_request(
         // with the `versions` (ListObjectVersions) query parameter.
         "GET" if has_query_param(target, "versioning") => {
             xml_response("200 OK", &versioning_enabled_page())
+        }
+        // ListObjectAnnotations (cp/mv annotation sync; `?annotation` with
+        // `x-id=ListObjectAnnotations`). Pages are endless until
+        // `finish_annotations` is set, keeping the child inside the
+        // library's (deliberately non-cancellable) listing loop until the
+        // test decides to let it finish.
+        "GET" if has_query_param(target, "annotation") => {
+            let page = annotation_pages_served.fetch_add(1, Ordering::SeqCst);
+            let truncated = !finish_annotations.load(Ordering::SeqCst);
+            xml_response("200 OK", &annotations_page(page, truncated))
         }
         // ListObjectsV2. Every object `GET` the AWS SDK issues carries
         // `x-id=GetObject` but never `list-type`, so this param is the
@@ -329,6 +357,21 @@ fn extract_tag(xml: &str, tag: &str) -> Option<String> {
     let start = xml.find(&open)? + open.len();
     let end = xml[start..].find(&close)? + start;
     Some(xml[start..end].to_string())
+}
+
+/// One `ListObjectAnnotations` page carrying a single annotation entry,
+/// truncated (continuation token present) or final. Shape mirrors the
+/// deserializer's expectations as pinned by s3util-rs's own paging tests.
+fn annotations_page(page: usize, truncated: bool) -> String {
+    let next_token = if truncated {
+        format!("<NextContinuationToken>ann-token-{page}</NextContinuationToken>")
+    } else {
+        String::new()
+    };
+    format!(
+        r#"<?xml version="1.0" encoding="UTF-8"?>
+<ListObjectAnnotationsOutput><Annotations><AnnotationEntry><AnnotationName>note-{page}</AnnotationName><LastModified>2026-01-01T00:00:00.000Z</LastModified><Size>1</Size></AnnotationEntry></Annotations>{next_token}</ListObjectAnnotationsOutput>"#
+    )
 }
 
 fn versioning_enabled_page() -> String {
@@ -701,6 +744,67 @@ fn sigint_during_mv_download_exits_130_and_never_deletes_source() {
     let _ = std::fs::remove_dir_all(&local_dir);
 }
 
+/// Ctrl+C during a `cp --dry-run` whose S3-to-S3 annotation listing is
+/// taking real network time. The dry-run path runs no transfer, but it must
+/// still install the Ctrl+C handler and report the interruption as a
+/// cancellation — before this fix the dry-run early return in
+/// `run_copy_phase` installed no handler and hard-coded `cancelled: false`,
+/// so inside batch-run the line would have finished as a success (upstream
+/// s3util-rs routes dry-run through the full flag-consulting phase);
+/// standalone, the process died to the default disposition instead of
+/// exiting gracefully.
+#[test]
+#[cfg(target_family = "unix")]
+fn sigint_during_cp_dry_run_annotation_listing_exits_130() {
+    let fake = spawn_fake_s3(None);
+    let mut args = vec![
+        "cp".to_string(),
+        "--dry-run".to_string(),
+        "--enable-sync-object-annotations".to_string(),
+    ];
+    args.extend(source_client_args(&fake.endpoint));
+    // `--aws-max-attempts` is a shared (not per-side) flag and is already
+    // supplied by the source set above; drop it from the target set (its
+    // last two elements) to avoid a duplicate-argument clap error.
+    let mut target_args = target_client_args(&fake.endpoint);
+    target_args.truncate(target_args.len() - 2);
+    args.extend(target_args);
+    args.push(format!("s3://{BUCKET}/annotated-src.bin"));
+    args.push(format!("s3://{BUCKET}/annotated-dst.bin"));
+    let mut child = spawn_s7cmd(&args);
+
+    wait_for_count(
+        &mut child,
+        &fake.annotation_pages_served,
+        3,
+        "annotation page(s)",
+    );
+    send_sigint(&child);
+    // The library's annotation listing loop deliberately ignores
+    // cancellation (annotation integrity), so end the listing from the
+    // fake's side: the next page is final, and the frontend must then
+    // report the interruption rather than the listing's success.
+    fake.finish_annotations.store(true, Ordering::SeqCst);
+
+    let status = wait_with_deadline(&mut child, Duration::from_secs(15));
+    let stderr = read_stderr(&mut child);
+
+    assert_eq!(
+        status.code(),
+        Some(130),
+        "[cp-dry-run] expected graceful exit 130 after SIGINT, got {status:?}\nstderr: {stderr}"
+    );
+    assert!(
+        !stderr.contains("panicked") && !stderr.contains("failed."),
+        "[cp-dry-run] SIGINT should terminate without failure logs\nstderr: {stderr}"
+    );
+    assert_eq!(
+        fake.object_gets_served.load(Ordering::SeqCst),
+        0,
+        "a dry run must never download objects"
+    );
+}
+
 // ---- batch-run ----
 
 /// A batch line interrupted by Ctrl+C: the `clean` line's cancellation
@@ -740,6 +844,77 @@ fn batch_run_clean_line_interrupted_by_sigint_exits_130() {
     assert!(
         !stderr.contains("panicked"),
         "SIGINT should terminate without panics\nstderr: {stderr}"
+    );
+
+    let _ = std::fs::remove_dir_all(&script_dir);
+}
+
+/// The parallel executor's spawn loop checks the interrupt flag at the top
+/// of each iteration, then awaits a semaphore permit — a window where a
+/// SIGINT can land while all workers are busy. The permit freed by an
+/// interrupted line must NOT dispatch the next queued line: its freshly
+/// installed Ctrl+C handler would never see the already-delivered signal,
+/// so it would run to full completion (real requests included) yet read
+/// the process-global interruption state stored by a sibling line and
+/// misreport as skipped. Guards the post-await interrupt re-check.
+///
+/// Layout: 2 workers, 3 lines. Lines 1-2 list endlessly on their own
+/// endpoints (both provably in flight before SIGINT), line 3 targets a
+/// third endpoint that must never receive a request.
+#[test]
+#[cfg(target_family = "unix")]
+fn batch_run_parallel_queued_line_after_sigint_never_runs() {
+    let busy_a = spawn_fake_s3(None);
+    let busy_b = spawn_fake_s3(None);
+    let queued = spawn_fake_s3(Some(1));
+    let script_dir = create_temp_dir("batch_run_parallel");
+    let script_path = script_dir.join("script.txt");
+    let ls_line = |endpoint: &str| {
+        format!(
+            "ls --recursive {} s3://{BUCKET}/",
+            target_client_args(endpoint).join(" "),
+        )
+    };
+    let script = format!(
+        "{}\n{}\n{}\n",
+        ls_line(&busy_a.endpoint),
+        ls_line(&busy_b.endpoint),
+        ls_line(&queued.endpoint),
+    );
+    std::fs::write(&script_path, script).expect("write batch script");
+
+    let args = vec![
+        "batch-run".to_string(),
+        "--parallel".to_string(),
+        "2".to_string(),
+        script_path.to_string_lossy().into_owned(),
+    ];
+    let mut child = spawn_s7cmd(&args);
+
+    // Both workers provably mid-listing => their Ctrl+C handlers are
+    // installed, both permits are held, and the spawn loop is parked on
+    // `acquire_owned().await` for line 3.
+    wait_for_count(&mut child, &busy_a.pages_served, 2, "list page(s) (line 1)");
+    wait_for_count(&mut child, &busy_b.pages_served, 2, "list page(s) (line 2)");
+    send_sigint(&child);
+
+    let status = wait_with_deadline(&mut child, Duration::from_secs(15));
+    let stderr = read_stderr(&mut child);
+
+    assert_eq!(
+        status.code(),
+        Some(130),
+        "expected batch-run to exit 130 after its lines were interrupted, got {status:?}\nstderr: {stderr}"
+    );
+    assert!(
+        !stderr.contains("panicked"),
+        "SIGINT should terminate without panics\nstderr: {stderr}"
+    );
+    assert_eq!(
+        queued.pages_served.load(Ordering::SeqCst),
+        0,
+        "the queued third line must not run after SIGINT (permit freed by an \
+         interrupted line must not dispatch it)\nstderr: {stderr}"
     );
 
     let _ = std::fs::remove_dir_all(&script_dir);

--- a/tests/cli_sigint_exit_code.rs
+++ b/tests/cli_sigint_exit_code.rs
@@ -1,0 +1,703 @@
+//! Process-level regression tests for SIGINT (Ctrl+C) exit-code handling
+//! in the pipeline subcommands (`ls`, `clean`, `sync`) and in `batch-run`.
+//!
+//! Each of these subcommands catches Ctrl+C, cancels its pipeline, and must
+//! then exit gracefully with code 130 (128 + SIGINT), the conventional shell
+//! encoding for a run interrupted by the user — matching what `cp`/`mv`
+//! already do via `ExitStatus::Cancelled`. These tests run the real binary
+//! against a minimal in-process S3 endpoint (no AWS access needed): the
+//! endpoint keeps returning truncated list pages so the run stays busy until
+//! the test sends SIGINT, and answers object `GET` (for `sync` downloads),
+//! batch `DeleteObjects`, and single-object `DeleteObject` requests so the
+//! later pipeline stages stay active as well.
+//!
+//! Covers the `is_ctrl_c_received()` → `SIGINT_EXIT_CODE` paths in
+//! `src/ls_bin/mod.rs`, `src/clean_bin/mod.rs`, and
+//! `src/sync_bin/cli/mod.rs` (ported from nidor1998/s3rm-rs#100 /
+//! nidor1998/s3ls-rs#34), plus batch-run's severity-ranked aggregation of a
+//! line that returns 130.
+
+use std::io::{Read as _, Write as _};
+use std::net::{TcpListener, TcpStream};
+use std::path::PathBuf;
+use std::process::{Child, Command, Stdio};
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+
+const BUCKET: &str = "fake-sigint-bucket";
+
+/// One-byte object body served for every object `GET`; the listing
+/// advertises `Size` 1 and the matching MD5 ETag so `sync` downloads it
+/// without complaint.
+const OBJECT_BODY: &str = "x";
+const OBJECT_ETAG: &str = "\"9dd4e461268c8034f5c8564e155c67a6\"";
+
+/// Handle to a fake S3 endpoint running on a background thread.
+struct FakeS3 {
+    endpoint: String,
+    pages_served: Arc<AtomicUsize>,
+    object_gets_served: Arc<AtomicUsize>,
+    deletes_served: Arc<AtomicUsize>,
+    deleted_keys: Arc<Mutex<Vec<String>>>,
+}
+
+/// Serve canned S3 responses over plain HTTP/1.1, one request per
+/// connection, serialized by the accept loop:
+///
+/// - `GET ?versioning` → versioning enabled
+/// - `GET ?list-type=2` (ListObjectsV2) → one page with one object,
+///   advancing its continuation token each time. With
+///   `total_pages = Some(n)` the n-th page is final (`IsTruncated` false);
+///   with `None` the listing is endless, so the child only stops when it
+///   is signalled.
+/// - `GET` / `HEAD` on an object key → the one-byte object (for `sync`)
+/// - `POST ?delete` (batch `DeleteObjects`) → echo every requested key
+///   back as `<Deleted>`
+/// - `DELETE` (single `DeleteObject`) → 204 No Content
+fn spawn_fake_s3(total_pages: Option<usize>) -> FakeS3 {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("failed to bind fake S3 listener");
+    let endpoint = format!("http://{}", listener.local_addr().unwrap());
+    let pages_served = Arc::new(AtomicUsize::new(0));
+    let object_gets_served = Arc::new(AtomicUsize::new(0));
+    let deletes_served = Arc::new(AtomicUsize::new(0));
+    let deleted_keys = Arc::new(Mutex::new(Vec::new()));
+
+    let pages = Arc::clone(&pages_served);
+    let gets = Arc::clone(&object_gets_served);
+    let deletes = Arc::clone(&deletes_served);
+    let keys = Arc::clone(&deleted_keys);
+    std::thread::spawn(move || {
+        for stream in listener.incoming() {
+            let Ok(mut stream) = stream else { break };
+            let _ = stream.set_read_timeout(Some(Duration::from_secs(10)));
+            let Some((request_line, request_body)) = read_request(&mut stream) else {
+                continue;
+            };
+
+            let response = route_request(
+                &request_line,
+                &request_body,
+                total_pages,
+                &pages,
+                &gets,
+                &deletes,
+                &keys,
+            );
+            let _ = stream.write_all(&response);
+            let _ = stream.flush();
+        }
+    });
+
+    FakeS3 {
+        endpoint,
+        pages_served,
+        object_gets_served,
+        deletes_served,
+        deleted_keys,
+    }
+}
+
+/// Read one HTTP request (head plus `content-length` body) and return its
+/// request line and body.
+fn read_request(stream: &mut TcpStream) -> Option<(String, String)> {
+    let mut data = Vec::new();
+    let mut buf = [0u8; 4096];
+    let header_end = loop {
+        match stream.read(&mut buf) {
+            Ok(0) => return None,
+            Ok(n) => {
+                data.extend_from_slice(&buf[..n]);
+                if let Some(pos) = data.windows(4).position(|w| w == b"\r\n\r\n") {
+                    break pos + 4;
+                }
+            }
+            Err(_) => return None,
+        }
+    };
+
+    let head = String::from_utf8_lossy(&data[..header_end]).to_string();
+    let request_line = head.lines().next().unwrap_or("").to_string();
+
+    let mut content_length = 0usize;
+    for line in head.lines().skip(1) {
+        if let Some((name, value)) = line.split_once(':')
+            && name.trim().eq_ignore_ascii_case("content-length")
+        {
+            content_length = value.trim().parse().unwrap_or(0);
+        }
+    }
+    while data.len() - header_end < content_length {
+        match stream.read(&mut buf) {
+            Ok(0) => break,
+            Ok(n) => data.extend_from_slice(&buf[..n]),
+            Err(_) => break,
+        }
+    }
+
+    let body = String::from_utf8_lossy(&data[header_end..]).to_string();
+    Some((request_line, body))
+}
+
+fn route_request(
+    request_line: &str,
+    request_body: &str,
+    total_pages: Option<usize>,
+    pages_served: &AtomicUsize,
+    object_gets_served: &AtomicUsize,
+    deletes_served: &AtomicUsize,
+    deleted_keys: &Mutex<Vec<String>>,
+) -> Vec<u8> {
+    let mut parts = request_line.split_whitespace();
+    let method = parts.next().unwrap_or("");
+    let target = parts.next().unwrap_or("");
+
+    match method {
+        // GetBucketVersioning (prerequisite checks). Must not be confused
+        // with the `versions` (ListObjectVersions) query parameter.
+        "GET" if has_query_param(target, "versioning") => {
+            xml_response("200 OK", &versioning_enabled_page())
+        }
+        // ListObjectsV2. Every object `GET` the AWS SDK issues carries
+        // `x-id=GetObject` but never `list-type`, so this param is the
+        // discriminator.
+        "GET" if has_query_param(target, "list-type") => {
+            let page = pages_served.fetch_add(1, Ordering::SeqCst);
+            let truncated = total_pages.is_none_or(|total| page + 1 < total);
+            xml_response("200 OK", &objects_page(page, truncated))
+        }
+        // Object GET / HEAD (sync's download stage).
+        "GET" | "HEAD" => {
+            if method == "GET" {
+                object_gets_served.fetch_add(1, Ordering::SeqCst);
+            }
+            object_response(method == "HEAD")
+        }
+        // Batch DeleteObjects: acknowledge every requested key as deleted.
+        "POST" if has_query_param(target, "delete") => {
+            let requested = parse_delete_request(request_body);
+            {
+                let mut recorded = deleted_keys.lock().unwrap();
+                recorded.extend(requested.iter().cloned());
+            }
+            deletes_served.fetch_add(1, Ordering::SeqCst);
+            xml_response("200 OK", &delete_result_page(&requested))
+        }
+        // Single-object DeleteObject.
+        "DELETE" => {
+            let path = target.split('?').next().unwrap_or("");
+            let key = path.rsplit('/').next().unwrap_or("").to_string();
+            deleted_keys.lock().unwrap().push(key);
+            deletes_served.fetch_add(1, Ordering::SeqCst);
+            b"HTTP/1.1 204 No Content\r\nconnection: close\r\n\r\n".to_vec()
+        }
+        _ => xml_response("400 Bad Request", ""),
+    }
+}
+
+fn xml_response(status_line: &str, body: &str) -> Vec<u8> {
+    format!(
+        "HTTP/1.1 {status_line}\r\ncontent-type: application/xml\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{body}",
+        body.len(),
+    )
+    .into_bytes()
+}
+
+/// The one-byte object every listing page advertises. Headers match the
+/// listing entry (size 1, MD5 ETag) so `sync` writes it without complaint.
+fn object_response(head_only: bool) -> Vec<u8> {
+    let mut response = format!(
+        "HTTP/1.1 200 OK\r\ncontent-type: application/octet-stream\r\ncontent-length: {}\r\netag: {OBJECT_ETAG}\r\nlast-modified: Thu, 01 Jan 2026 00:00:00 GMT\r\naccept-ranges: bytes\r\nconnection: close\r\n\r\n",
+        OBJECT_BODY.len(),
+    )
+    .into_bytes();
+    if !head_only {
+        response.extend_from_slice(OBJECT_BODY.as_bytes());
+    }
+    response
+}
+
+/// Whether the request target carries the query parameter `name`
+/// (`?versioning` matches `versioning` but not `versions`).
+fn has_query_param(target: &str, name: &str) -> bool {
+    target
+        .split_once('?')
+        .map(|(_, query)| {
+            query
+                .split('&')
+                .any(|param| param.split('=').next() == Some(name))
+        })
+        .unwrap_or(false)
+}
+
+/// Extract the keys from a `DeleteObjects` request body.
+fn parse_delete_request(body: &str) -> Vec<String> {
+    body.split("<Object>")
+        .skip(1)
+        .map(|chunk| {
+            let object = chunk.split("</Object>").next().unwrap_or(chunk);
+            extract_tag(object, "Key").unwrap_or_default()
+        })
+        .collect()
+}
+
+fn extract_tag(xml: &str, tag: &str) -> Option<String> {
+    let open = format!("<{tag}>");
+    let close = format!("</{tag}>");
+    let start = xml.find(&open)? + open.len();
+    let end = xml[start..].find(&close)? + start;
+    Some(xml[start..end].to_string())
+}
+
+fn versioning_enabled_page() -> String {
+    r#"<?xml version="1.0" encoding="UTF-8"?>
+<VersioningConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Status>Enabled</Status></VersioningConfiguration>"#
+        .to_string()
+}
+
+fn objects_page(page: usize, truncated: bool) -> String {
+    let next_token = if truncated {
+        format!("<NextContinuationToken>token-{page}</NextContinuationToken>")
+    } else {
+        String::new()
+    };
+    format!(
+        r#"<?xml version="1.0" encoding="UTF-8"?>
+<ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>{BUCKET}</Name><Prefix></Prefix><KeyCount>1</KeyCount><MaxKeys>1000</MaxKeys><IsTruncated>{truncated}</IsTruncated>{next_token}<Contents><Key>page-{page}.txt</Key><LastModified>2026-01-01T00:00:00.000Z</LastModified><ETag>&quot;9dd4e461268c8034f5c8564e155c67a6&quot;</ETag><Size>1</Size><StorageClass>STANDARD</StorageClass></Contents></ListBucketResult>"#
+    )
+}
+
+fn delete_result_page(deleted: &[String]) -> String {
+    let mut entries = String::new();
+    for key in deleted {
+        entries.push_str(&format!("<Deleted><Key>{key}</Key></Deleted>"));
+    }
+    format!(
+        r#"<?xml version="1.0" encoding="UTF-8"?>
+<DeleteResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/">{entries}</DeleteResult>"#
+    )
+}
+
+/// `--target-*` client flags pointing at the fake endpoint with static
+/// credentials, so no profile, IMDS, or config-file lookup happens and no
+/// retries blur the request↔response accounting.
+fn target_client_args(endpoint: &str) -> Vec<String> {
+    [
+        "--target-endpoint-url",
+        endpoint,
+        "--target-access-key",
+        "fake-access-key",
+        "--target-secret-access-key",
+        "fake-secret-key",
+        "--target-region",
+        "us-east-1",
+        "--aws-max-attempts",
+        "1",
+    ]
+    .iter()
+    .map(|s| s.to_string())
+    .collect()
+}
+
+/// [`target_client_args`] with `--source-*` prefixes (for `sync`, whose S3
+/// side in these tests is the source).
+fn source_client_args(endpoint: &str) -> Vec<String> {
+    target_client_args(endpoint)
+        .iter()
+        .map(|s| s.replace("--target-", "--source-"))
+        .collect()
+}
+
+/// Spawn the s7cmd binary with ambient environment that could redirect the
+/// run scrubbed away (same scrub set as `common::s7cmd_cmd_clean_env`), so
+/// the child talks only to the fake endpoint.
+fn spawn_s7cmd(args: &[String]) -> Child {
+    Command::new(env!("CARGO_BIN_EXE_s7cmd"))
+        .args(args)
+        .env_remove("RUST_LOG")
+        .env_remove("AWS_PROFILE")
+        .env_remove("AWS_ENDPOINT_URL")
+        .env_remove("AWS_ENDPOINT_URL_S3")
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("failed to spawn s7cmd")
+}
+
+/// Fresh per-test scratch directory (used as sync's local target).
+fn create_temp_dir(label: &str) -> PathBuf {
+    let nanos = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_nanos();
+    let dir = std::env::temp_dir().join(format!(
+        "s7cmd_sigint_{label}_{}_{nanos}",
+        std::process::id()
+    ));
+    std::fs::create_dir_all(&dir).expect("create temp dir");
+    dir
+}
+
+/// Wait until the fake endpoint has served at least `at_least` requests
+/// counted by `counter`, so the child is provably inside the pipeline (its
+/// Ctrl+C handler is installed before the pipeline starts, thus long since
+/// registered). Fails fast with the child's stderr if it exits early.
+#[cfg(target_family = "unix")]
+fn wait_for_count(child: &mut Child, counter: &AtomicUsize, at_least: usize, what: &str) {
+    let deadline = Instant::now() + Duration::from_secs(30);
+    while counter.load(Ordering::SeqCst) < at_least {
+        if let Some(status) = child.try_wait().expect("failed to poll s7cmd") {
+            let stderr = read_stderr(child);
+            panic!(
+                "s7cmd exited ({status:?}) before the fake S3 served {at_least} {what}\nstderr: {stderr}"
+            );
+        }
+        assert!(
+            Instant::now() < deadline,
+            "fake S3 served only {} {what} before timeout",
+            counter.load(Ordering::SeqCst)
+        );
+        std::thread::sleep(Duration::from_millis(10));
+    }
+}
+
+/// Wait for the child to exit within `deadline` — SIGINT must terminate
+/// the process promptly, not hang it. Kills the child on timeout.
+fn wait_with_deadline(child: &mut Child, deadline: Duration) -> std::process::ExitStatus {
+    let end = Instant::now() + deadline;
+    loop {
+        if let Some(status) = child.try_wait().expect("failed to poll s7cmd") {
+            return status;
+        }
+        if Instant::now() >= end {
+            let _ = child.kill();
+            let _ = child.wait();
+            panic!("s7cmd did not exit within {deadline:?}");
+        }
+        std::thread::sleep(Duration::from_millis(10));
+    }
+}
+
+/// Read the child's stderr after it has exited.
+fn read_stderr(child: &mut Child) -> String {
+    let mut stderr = String::new();
+    if let Some(mut pipe) = child.stderr.take() {
+        let _ = pipe.read_to_string(&mut stderr);
+    }
+    stderr
+}
+
+#[cfg(target_family = "unix")]
+fn send_sigint(child: &Child) {
+    nix::sys::signal::kill(
+        nix::unistd::Pid::from_raw(child.id() as i32),
+        nix::sys::signal::Signal::SIGINT,
+    )
+    .expect("failed to send SIGINT to s7cmd");
+}
+
+/// Interrupt the child and require a graceful exit with code 130 —
+/// `code()` is `None` for a raw signal kill, so this also proves the
+/// signal was caught rather than terminating the process directly — and a
+/// stderr free of panics and terminal failure logs.
+#[cfg(target_family = "unix")]
+fn interrupt_and_expect_130(mut child: Child, label: &str) {
+    send_sigint(&child);
+
+    let status = wait_with_deadline(&mut child, Duration::from_secs(15));
+    let stderr = read_stderr(&mut child);
+
+    assert_eq!(
+        status.code(),
+        Some(130),
+        "[{label}] expected graceful exit 130 after SIGINT, got {status:?}\nstderr: {stderr}"
+    );
+    assert!(
+        !stderr.contains("panicked") && !stderr.contains("failed."),
+        "[{label}] SIGINT should terminate without failure logs\nstderr: {stderr}"
+    );
+}
+
+// ---- ls ----
+
+/// Ctrl+C during a recursive listing (parallel-listing dispatch).
+#[test]
+#[cfg(target_family = "unix")]
+fn sigint_during_ls_recursive_listing_exits_130() {
+    let fake = spawn_fake_s3(None);
+    let mut args = vec!["ls".to_string(), "--recursive".to_string()];
+    args.extend(target_client_args(&fake.endpoint));
+    args.push(format!("s3://{BUCKET}/"));
+    let mut child = spawn_s7cmd(&args);
+
+    wait_for_count(&mut child, &fake.pages_served, 3, "list page(s)");
+    interrupt_and_expect_130(child, "ls-recursive");
+}
+
+/// Ctrl+C during the default (delimiter, sequential) listing.
+#[test]
+#[cfg(target_family = "unix")]
+fn sigint_during_ls_delimiter_listing_exits_130() {
+    let fake = spawn_fake_s3(None);
+    let mut args = vec!["ls".to_string()];
+    args.extend(target_client_args(&fake.endpoint));
+    args.push(format!("s3://{BUCKET}/"));
+    let mut child = spawn_s7cmd(&args);
+
+    wait_for_count(&mut child, &fake.pages_served, 3, "list page(s)");
+    interrupt_and_expect_130(child, "ls-delimiter");
+}
+
+// ---- clean ----
+
+/// Ctrl+C during a `--dry-run` listing: only list requests are ever in
+/// flight, and none may turn into deletions during shutdown.
+#[test]
+#[cfg(target_family = "unix")]
+fn sigint_during_clean_dry_run_listing_exits_130() {
+    let fake = spawn_fake_s3(None);
+    let mut args = vec![
+        "clean".to_string(),
+        "--dry-run".to_string(),
+        "--max-parallel-listings".to_string(),
+        "1".to_string(),
+    ];
+    args.extend(target_client_args(&fake.endpoint));
+    args.push(format!("s3://{BUCKET}/"));
+    let mut child = spawn_s7cmd(&args);
+
+    wait_for_count(&mut child, &fake.pages_served, 3, "list page(s)");
+    interrupt_and_expect_130(child, "clean-dry-run");
+
+    assert_eq!(
+        fake.deletes_served.load(Ordering::SeqCst),
+        0,
+        "a dry run must never send delete requests"
+    );
+}
+
+/// Ctrl+C while batch `DeleteObjects` requests are actively being sent
+/// (`--batch-size 2` flushes a batch every two listed objects).
+#[test]
+#[cfg(target_family = "unix")]
+fn sigint_during_clean_batch_deletion_exits_130() {
+    let fake = spawn_fake_s3(None);
+    let mut args = vec![
+        "clean".to_string(),
+        "--force".to_string(),
+        "--batch-size".to_string(),
+        "2".to_string(),
+        "--max-parallel-listings".to_string(),
+        "1".to_string(),
+    ];
+    args.extend(target_client_args(&fake.endpoint));
+    args.push(format!("s3://{BUCKET}/"));
+    let mut child = spawn_s7cmd(&args);
+
+    wait_for_count(&mut child, &fake.pages_served, 3, "list page(s)");
+    wait_for_count(&mut child, &fake.deletes_served, 1, "delete request(s)");
+    interrupt_and_expect_130(child, "clean-batch");
+}
+
+/// Ctrl+C while single-object `DeleteObject` requests (`--batch-size 1`)
+/// are actively being sent.
+#[test]
+#[cfg(target_family = "unix")]
+fn sigint_during_clean_single_object_deletion_exits_130() {
+    let fake = spawn_fake_s3(None);
+    let mut args = vec![
+        "clean".to_string(),
+        "--force".to_string(),
+        "--batch-size".to_string(),
+        "1".to_string(),
+        "--max-parallel-listings".to_string(),
+        "1".to_string(),
+    ];
+    args.extend(target_client_args(&fake.endpoint));
+    args.push(format!("s3://{BUCKET}/"));
+    let mut child = spawn_s7cmd(&args);
+
+    wait_for_count(&mut child, &fake.pages_served, 3, "list page(s)");
+    wait_for_count(&mut child, &fake.deletes_served, 2, "delete request(s)");
+    interrupt_and_expect_130(child, "clean-single");
+}
+
+// ---- sync ----
+
+/// Ctrl+C during a `--dry-run` sync listing: only list requests are ever
+/// in flight, and no object may be downloaded during shutdown.
+#[test]
+#[cfg(target_family = "unix")]
+fn sigint_during_sync_dry_run_listing_exits_130() {
+    let fake = spawn_fake_s3(None);
+    let local_dir = create_temp_dir("sync_dry_run");
+    let mut args = vec!["sync".to_string(), "--dry-run".to_string()];
+    args.extend(source_client_args(&fake.endpoint));
+    args.push(format!("s3://{BUCKET}/"));
+    args.push(format!("{}/", local_dir.to_string_lossy()));
+    let mut child = spawn_s7cmd(&args);
+
+    wait_for_count(&mut child, &fake.pages_served, 3, "list page(s)");
+    interrupt_and_expect_130(child, "sync-dry-run");
+
+    assert_eq!(
+        fake.object_gets_served.load(Ordering::SeqCst),
+        0,
+        "a dry run must never download objects"
+    );
+    let _ = std::fs::remove_dir_all(&local_dir);
+}
+
+/// Ctrl+C while `sync` is actively downloading objects (list pages and
+/// object `GET`s both in flight).
+#[test]
+#[cfg(target_family = "unix")]
+fn sigint_during_sync_download_exits_130() {
+    let fake = spawn_fake_s3(None);
+    let local_dir = create_temp_dir("sync_download");
+    let mut args = vec!["sync".to_string()];
+    args.extend(source_client_args(&fake.endpoint));
+    args.push(format!("s3://{BUCKET}/"));
+    args.push(format!("{}/", local_dir.to_string_lossy()));
+    let mut child = spawn_s7cmd(&args);
+
+    wait_for_count(&mut child, &fake.pages_served, 3, "list page(s)");
+    wait_for_count(&mut child, &fake.object_gets_served, 2, "object GET(s)");
+    interrupt_and_expect_130(child, "sync-download");
+
+    let _ = std::fs::remove_dir_all(&local_dir);
+}
+
+// ---- batch-run ----
+
+/// A batch line interrupted by Ctrl+C: the `clean` line's cancellation
+/// handler makes it return 130 in-process (batch-run must survive — the
+/// engines return the code instead of calling `process::exit`), the
+/// executor buckets it as skipped, and the severity-ranked batch exit code
+/// surfaces 130 (any-other-non-zero outranks 0).
+#[test]
+#[cfg(target_family = "unix")]
+fn batch_run_clean_line_interrupted_by_sigint_exits_130() {
+    let fake = spawn_fake_s3(None);
+    let script_dir = create_temp_dir("batch_run");
+    let script_path = script_dir.join("script.txt");
+    let line = format!(
+        "clean --force --batch-size 2 --max-parallel-listings 1 {} s3://{BUCKET}/",
+        target_client_args(&fake.endpoint).join(" "),
+    );
+    std::fs::write(&script_path, format!("{line}\n")).expect("write batch script");
+
+    let args = vec![
+        "batch-run".to_string(),
+        script_path.to_string_lossy().into_owned(),
+    ];
+    let mut child = spawn_s7cmd(&args);
+
+    wait_for_count(&mut child, &fake.pages_served, 3, "list page(s)");
+    send_sigint(&child);
+
+    let status = wait_with_deadline(&mut child, Duration::from_secs(15));
+    let stderr = read_stderr(&mut child);
+
+    assert_eq!(
+        status.code(),
+        Some(130),
+        "expected batch-run to exit 130 after its line was interrupted, got {status:?}\nstderr: {stderr}"
+    );
+    assert!(
+        !stderr.contains("panicked"),
+        "SIGINT should terminate without panics\nstderr: {stderr}"
+    );
+
+    let _ = std::fs::remove_dir_all(&script_dir);
+}
+
+// ---- no-SIGINT controls ----
+//
+// The same harness without SIGINT must complete the full run and exit 0 —
+// the SIGINT handling must not affect uninterrupted runs. These also prove
+// the fake endpoint drives each pipeline to a genuine completion, so the
+// SIGINT tests above interrupt a run that would otherwise have succeeded.
+
+#[test]
+fn ls_without_sigint_exits_zero() {
+    let fake = spawn_fake_s3(Some(3));
+    let mut args = vec!["ls".to_string()];
+    args.extend(target_client_args(&fake.endpoint));
+    args.push(format!("s3://{BUCKET}/"));
+    let mut child = spawn_s7cmd(&args);
+
+    let status = wait_with_deadline(&mut child, Duration::from_secs(30));
+    let stderr = read_stderr(&mut child);
+
+    assert_eq!(
+        status.code(),
+        Some(0),
+        "expected exit 0, got {status:?}\nstderr: {stderr}"
+    );
+    assert_eq!(fake.pages_served.load(Ordering::SeqCst), 3);
+}
+
+#[test]
+fn clean_without_sigint_exits_zero() {
+    let fake = spawn_fake_s3(Some(3));
+    let mut args = vec![
+        "clean".to_string(),
+        "--force".to_string(),
+        "--max-parallel-listings".to_string(),
+        "1".to_string(),
+    ];
+    args.extend(target_client_args(&fake.endpoint));
+    args.push(format!("s3://{BUCKET}/"));
+    let mut child = spawn_s7cmd(&args);
+
+    let status = wait_with_deadline(&mut child, Duration::from_secs(30));
+    let stderr = read_stderr(&mut child);
+
+    assert_eq!(
+        status.code(),
+        Some(0),
+        "expected exit 0, got {status:?}\nstderr: {stderr}"
+    );
+    assert_eq!(fake.pages_served.load(Ordering::SeqCst), 3);
+    assert!(
+        fake.deletes_served.load(Ordering::SeqCst) >= 1,
+        "the run must have sent at least one delete request"
+    );
+    let deleted = fake.deleted_keys.lock().unwrap();
+    for key in ["page-0.txt", "page-1.txt", "page-2.txt"] {
+        assert!(
+            deleted.iter().any(|deleted_key| deleted_key == key),
+            "delete requests missing {key}; deleted: {deleted:?}"
+        );
+    }
+}
+
+#[test]
+fn sync_without_sigint_exits_zero() {
+    let fake = spawn_fake_s3(Some(3));
+    let local_dir = create_temp_dir("sync_control");
+    let mut args = vec!["sync".to_string()];
+    args.extend(source_client_args(&fake.endpoint));
+    args.push(format!("s3://{BUCKET}/"));
+    args.push(format!("{}/", local_dir.to_string_lossy()));
+    let mut child = spawn_s7cmd(&args);
+
+    let status = wait_with_deadline(&mut child, Duration::from_secs(30));
+    let stderr = read_stderr(&mut child);
+
+    assert_eq!(
+        status.code(),
+        Some(0),
+        "expected exit 0, got {status:?}\nstderr: {stderr}"
+    );
+    assert_eq!(fake.pages_served.load(Ordering::SeqCst), 3);
+    for key in ["page-0.txt", "page-1.txt", "page-2.txt"] {
+        let path = local_dir.join(key);
+        let body = std::fs::read_to_string(&path)
+            .unwrap_or_else(|e| panic!("sync must have downloaded {key}: {e}"));
+        assert_eq!(body, OBJECT_BODY, "downloaded body mismatch for {key}");
+    }
+    let _ = std::fs::remove_dir_all(&local_dir);
+}

--- a/tests/cli_sigint_exit_code.rs
+++ b/tests/cli_sigint_exit_code.rs
@@ -49,17 +49,24 @@ const STALLED_OBJECT_SIZE: usize = 1024 * 1024;
 const STALLED_OBJECT_PREFIX: usize = 1024;
 
 /// Handle to a fake S3 endpoint running on a background thread.
+///
+/// The fields below marked `cfg_attr(..., allow(dead_code))` are read only
+/// by the unix-gated SIGINT tests; without the attribute they warn as
+/// never-read on Windows, where only the no-SIGINT control tests run.
 struct FakeS3 {
     endpoint: String,
     pages_served: Arc<AtomicUsize>,
+    #[cfg_attr(not(target_family = "unix"), allow(dead_code))]
     object_gets_served: Arc<AtomicUsize>,
     deletes_served: Arc<AtomicUsize>,
     deleted_keys: Arc<Mutex<Vec<String>>>,
+    #[cfg_attr(not(target_family = "unix"), allow(dead_code))]
     annotation_pages_served: Arc<AtomicUsize>,
     /// While false, `ListObjectAnnotations` responses carry a continuation
     /// token (endless listing); set to true to make the next response the
     /// final page. The annotation listing loop is deliberately
     /// non-cancellable in the library, so tests end it from the outside.
+    #[cfg_attr(not(target_family = "unix"), allow(dead_code))]
     finish_annotations: Arc<AtomicBool>,
 }
 
@@ -86,6 +93,10 @@ fn spawn_fake_s3(total_pages: Option<usize>) -> FakeS3 {
 /// the connection open — so the child is provably blocked mid-download
 /// when the test sends SIGINT, and the forced shutdown that follows
 /// surfaces whatever error the aborted body read produces.
+///
+/// Called only by the unix-gated SIGINT tests, hence the Windows
+/// dead-code allowance.
+#[cfg_attr(not(target_family = "unix"), allow(dead_code))]
 fn spawn_fake_s3_stalled_objects() -> FakeS3 {
     spawn_fake_s3_impl(None, true)
 }

--- a/tests/cli_sigint_exit_code.rs
+++ b/tests/cli_sigint_exit_code.rs
@@ -1,21 +1,27 @@
 //! Process-level regression tests for SIGINT (Ctrl+C) exit-code handling
-//! in the pipeline subcommands (`ls`, `clean`, `sync`) and in `batch-run`.
+//! in the pipeline subcommands (`ls`, `clean`, `sync`, `cp`, `mv`) and in
+//! `batch-run`.
 //!
 //! Each of these subcommands catches Ctrl+C, cancels its pipeline, and must
 //! then exit gracefully with code 130 (128 + SIGINT), the conventional shell
-//! encoding for a run interrupted by the user — matching what `cp`/`mv`
-//! already do via `ExitStatus::Cancelled`. These tests run the real binary
-//! against a minimal in-process S3 endpoint (no AWS access needed): the
-//! endpoint keeps returning truncated list pages so the run stays busy until
-//! the test sends SIGINT, and answers object `GET` (for `sync` downloads),
-//! batch `DeleteObjects`, and single-object `DeleteObject` requests so the
-//! later pipeline stages stay active as well.
+//! encoding for a run interrupted by the user. These tests run the real
+//! binary against a minimal in-process S3 endpoint (no AWS access needed):
+//! the endpoint keeps returning truncated list pages so the run stays busy
+//! until the test sends SIGINT, and answers object `GET` (for `sync`
+//! downloads), batch `DeleteObjects`, and single-object `DeleteObject`
+//! requests so the later pipeline stages stay active as well. For `cp`/`mv`
+//! the endpoint instead serves an object whose body stalls after a small
+//! prefix, so the interrupt arrives while the transfer is blocked
+//! mid-download.
 //!
 //! Covers the `is_ctrl_c_received()` → `SIGINT_EXIT_CODE` paths in
 //! `src/ls_bin/mod.rs`, `src/clean_bin/mod.rs`, and
-//! `src/sync_bin/cli/mod.rs` (ported from nidor1998/s3rm-rs#100 /
-//! nidor1998/s3ls-rs#34), plus batch-run's severity-ranked aggregation of a
-//! line that returns 130.
+//! `src/sync_bin/cli/mod.rs` (ported from s3rm-rs 1.6.0 / s3ls-rs 1.3.0;
+//! upstream s3sync adopted the same fix in 1.62.0), the
+//! `is_ctrl_c_received()`-over-shutdown-error precedence in
+//! `src/util_bin/cli/mod.rs::run_copy_phase` (ported from s3util-rs
+//! 1.10.0), plus batch-run's severity-ranked aggregation of a line that
+//! returns 130.
 
 use std::io::{Read as _, Write as _};
 use std::net::{TcpListener, TcpStream};
@@ -32,6 +38,15 @@ const BUCKET: &str = "fake-sigint-bucket";
 /// without complaint.
 const OBJECT_BODY: &str = "x";
 const OBJECT_ETAG: &str = "\"9dd4e461268c8034f5c8564e155c67a6\"";
+
+/// Size advertised for the stalled object (see
+/// [`spawn_fake_s3_stalled_objects`]): large enough that the child is
+/// guaranteed to still be reading the body when SIGINT arrives, small
+/// enough to stay below any multipart-download threshold so the transfer
+/// is a single `GET`.
+const STALLED_OBJECT_SIZE: usize = 1024 * 1024;
+/// Body bytes actually written before the response stalls.
+const STALLED_OBJECT_PREFIX: usize = 1024;
 
 /// Handle to a fake S3 endpoint running on a background thread.
 struct FakeS3 {
@@ -56,6 +71,20 @@ struct FakeS3 {
 ///   back as `<Deleted>`
 /// - `DELETE` (single `DeleteObject`) → 204 No Content
 fn spawn_fake_s3(total_pages: Option<usize>) -> FakeS3 {
+    spawn_fake_s3_impl(total_pages, false)
+}
+
+/// [`spawn_fake_s3`] variant for the `cp`/`mv` SIGINT tests: object `HEAD`
+/// advertises a [`STALLED_OBJECT_SIZE`]-byte object, and object `GET`
+/// writes only a [`STALLED_OBJECT_PREFIX`]-byte body prefix and then holds
+/// the connection open — so the child is provably blocked mid-download
+/// when the test sends SIGINT, and the forced shutdown that follows
+/// surfaces whatever error the aborted body read produces.
+fn spawn_fake_s3_stalled_objects() -> FakeS3 {
+    spawn_fake_s3_impl(None, true)
+}
+
+fn spawn_fake_s3_impl(total_pages: Option<usize>, stall_object_bodies: bool) -> FakeS3 {
     let listener = TcpListener::bind("127.0.0.1:0").expect("failed to bind fake S3 listener");
     let endpoint = format!("http://{}", listener.local_addr().unwrap());
     let pages_served = Arc::new(AtomicUsize::new(0));
@@ -74,6 +103,19 @@ fn spawn_fake_s3(total_pages: Option<usize>) -> FakeS3 {
             let Some((request_line, request_body)) = read_request(&mut stream) else {
                 continue;
             };
+
+            if stall_object_bodies && is_object_request(&request_line) {
+                let head_only = request_line.starts_with("HEAD");
+                if !head_only {
+                    gets.fetch_add(1, Ordering::SeqCst);
+                }
+                let _ = stream.write_all(&stalled_object_response(head_only));
+                let _ = stream.flush();
+                if !head_only {
+                    hold_until_peer_closes(&mut stream);
+                }
+                continue;
+            }
 
             let response = route_request(
                 &request_line,
@@ -95,6 +137,46 @@ fn spawn_fake_s3(total_pages: Option<usize>) -> FakeS3 {
         object_gets_served,
         deletes_served,
         deleted_keys,
+    }
+}
+
+/// Whether the request is an object `GET`/`HEAD` (as opposed to a bucket
+/// subresource query like `?versioning` or a `?list-type=2` listing).
+fn is_object_request(request_line: &str) -> bool {
+    let mut parts = request_line.split_whitespace();
+    let method = parts.next().unwrap_or("");
+    let target = parts.next().unwrap_or("");
+    (method == "GET" || method == "HEAD")
+        && !has_query_param(target, "versioning")
+        && !has_query_param(target, "list-type")
+}
+
+/// Response for the stalled object: full headers advertising
+/// [`STALLED_OBJECT_SIZE`] bytes, but (for `GET`) only a
+/// [`STALLED_OBJECT_PREFIX`]-byte body prefix — the caller then keeps the
+/// connection open so the client blocks waiting for the rest.
+fn stalled_object_response(head_only: bool) -> Vec<u8> {
+    let mut response = format!(
+        "HTTP/1.1 200 OK\r\ncontent-type: application/octet-stream\r\ncontent-length: {STALLED_OBJECT_SIZE}\r\netag: \"fakestalledobjectetag\"\r\nlast-modified: Thu, 01 Jan 2026 00:00:00 GMT\r\naccept-ranges: bytes\r\nconnection: close\r\n\r\n",
+    )
+    .into_bytes();
+    if !head_only {
+        response.extend(std::iter::repeat_n(b'x', STALLED_OBJECT_PREFIX));
+    }
+    response
+}
+
+/// Hold the connection open without sending further body bytes until the
+/// peer closes it (the child exited) or the socket read times out. Blocks
+/// the accept loop, which is fine: the stalled `GET` is the last request a
+/// `cp`/`mv` run issues before it is interrupted.
+fn hold_until_peer_closes(stream: &mut TcpStream) {
+    let mut discard = [0u8; 512];
+    loop {
+        match stream.read(&mut discard) {
+            Ok(0) | Err(_) => return,
+            Ok(_) => {}
+        }
     }
 }
 
@@ -569,6 +651,56 @@ fn sigint_during_sync_download_exits_130() {
     let _ = std::fs::remove_dir_all(&local_dir);
 }
 
+// ---- cp / mv ----
+
+/// Ctrl+C while `cp` is blocked mid-download. The stalled body means the
+/// forced shutdown surfaces whatever error the aborted read produces (not
+/// necessarily a clean `Cancelled`), and the interruption must still win:
+/// exit 130, no failure report — the `is_ctrl_c_received()` precedence in
+/// `run_copy_phase`, ported from s3util-rs 1.10.0.
+#[test]
+#[cfg(target_family = "unix")]
+fn sigint_during_cp_download_exits_130() {
+    let fake = spawn_fake_s3_stalled_objects();
+    let local_dir = create_temp_dir("cp_download");
+    let mut args = vec!["cp".to_string()];
+    args.extend(source_client_args(&fake.endpoint));
+    args.push(format!("s3://{BUCKET}/stalled-object.bin"));
+    args.push(format!("{}/", local_dir.to_string_lossy()));
+    let mut child = spawn_s7cmd(&args);
+
+    wait_for_count(&mut child, &fake.object_gets_served, 1, "object GET(s)");
+    interrupt_and_expect_130(child, "cp-download");
+
+    let _ = std::fs::remove_dir_all(&local_dir);
+}
+
+/// Ctrl+C while `mv` is blocked mid-download: same 130 guarantee as `cp`,
+/// plus the safety half of the contract — an interrupted `mv` must never
+/// have deleted its source object.
+#[test]
+#[cfg(target_family = "unix")]
+fn sigint_during_mv_download_exits_130_and_never_deletes_source() {
+    let fake = spawn_fake_s3_stalled_objects();
+    let local_dir = create_temp_dir("mv_download");
+    let mut args = vec!["mv".to_string()];
+    args.extend(source_client_args(&fake.endpoint));
+    args.push(format!("s3://{BUCKET}/stalled-object.bin"));
+    args.push(format!("{}/", local_dir.to_string_lossy()));
+    let mut child = spawn_s7cmd(&args);
+
+    wait_for_count(&mut child, &fake.object_gets_served, 1, "object GET(s)");
+    interrupt_and_expect_130(child, "mv-download");
+
+    assert_eq!(
+        fake.deletes_served.load(Ordering::SeqCst),
+        0,
+        "an interrupted mv must never delete the source object; deleted: {:?}",
+        fake.deleted_keys.lock().unwrap()
+    );
+    let _ = std::fs::remove_dir_all(&local_dir);
+}
+
 // ---- batch-run ----
 
 /// A batch line interrupted by Ctrl+C: the `clean` line's cancellation
@@ -672,6 +804,67 @@ fn clean_without_sigint_exits_zero() {
             "delete requests missing {key}; deleted: {deleted:?}"
         );
     }
+}
+
+#[test]
+fn cp_without_sigint_exits_zero() {
+    let fake = spawn_fake_s3(Some(1));
+    let local_dir = create_temp_dir("cp_control");
+    let mut args = vec!["cp".to_string()];
+    args.extend(source_client_args(&fake.endpoint));
+    args.push(format!("s3://{BUCKET}/object.txt"));
+    args.push(format!("{}/", local_dir.to_string_lossy()));
+    let mut child = spawn_s7cmd(&args);
+
+    let status = wait_with_deadline(&mut child, Duration::from_secs(30));
+    let stderr = read_stderr(&mut child);
+
+    assert_eq!(
+        status.code(),
+        Some(0),
+        "expected exit 0, got {status:?}\nstderr: {stderr}"
+    );
+    let body = std::fs::read_to_string(local_dir.join("object.txt"))
+        .unwrap_or_else(|e| panic!("cp must have downloaded object.txt: {e}"));
+    assert_eq!(body, OBJECT_BODY, "downloaded body mismatch");
+    let _ = std::fs::remove_dir_all(&local_dir);
+}
+
+#[test]
+fn mv_without_sigint_exits_zero_and_deletes_source() {
+    let fake = spawn_fake_s3(Some(1));
+    let local_dir = create_temp_dir("mv_control");
+    let mut args = vec!["mv".to_string()];
+    args.extend(source_client_args(&fake.endpoint));
+    args.push(format!("s3://{BUCKET}/object.txt"));
+    args.push(format!("{}/", local_dir.to_string_lossy()));
+    let mut child = spawn_s7cmd(&args);
+
+    let status = wait_with_deadline(&mut child, Duration::from_secs(30));
+    let stderr = read_stderr(&mut child);
+
+    assert_eq!(
+        status.code(),
+        Some(0),
+        "expected exit 0, got {status:?}\nstderr: {stderr}"
+    );
+    let body = std::fs::read_to_string(local_dir.join("object.txt"))
+        .unwrap_or_else(|e| panic!("mv must have downloaded object.txt: {e}"));
+    assert_eq!(body, OBJECT_BODY, "downloaded body mismatch");
+    assert!(
+        fake.deletes_served.load(Ordering::SeqCst) >= 1,
+        "a completed mv must delete the source object"
+    );
+    assert!(
+        fake.deleted_keys
+            .lock()
+            .unwrap()
+            .iter()
+            .any(|key| key == "object.txt"),
+        "delete requests missing object.txt; deleted: {:?}",
+        fake.deleted_keys.lock().unwrap()
+    );
+    let _ = std::fs::remove_dir_all(&local_dir);
 }
 
 #[test]

--- a/tests/e2e_ctrl_c.rs
+++ b/tests/e2e_ctrl_c.rs
@@ -369,20 +369,29 @@ async fn cancel_ls_sigint_mid_paginated_listing_exits_130() {
     helper.delete_bucket_with_cascade(&bucket).await;
 }
 
-/// clean over 200 objects with `--batch-size 10 --rate-limit-objects 10`
-/// keeps the deletion pipeline busy for ~20s of theoretical work, so SIGINT
-/// lands mid-run at any delay in `STARTUP_DELAYS_MS` (at most 9s) and
-/// drives the post-run "deletion cancelled by user" branch (exit 130). A
-/// leaky-bucket burst that drained the bucket before the signal would
-/// surface as exit 0 here — that would mean the throttle window shrank and
-/// the workload needs re-tuning, not that the cancellation path regressed.
+/// clean over 300 objects with `--worker-size 1 --batch-size 10
+/// --rate-limit-objects 10` keeps the deletion pipeline busy for ~29s of
+/// deterministic work, so SIGINT lands mid-run at any delay in
+/// `STARTUP_DELAYS_MS` (at most 9s) and drives the post-run "deletion
+/// cancelled by user" branch (exit 130).
+///
+/// Margin math — the workload must survive `run_with_sigint`'s retry
+/// escalation, which re-runs `clean` on the SAME (partially drained)
+/// bucket: the single worker serializes batches, so each fresh process
+/// drains at most the 10-token initial burst plus 10 objects/sec of run
+/// time. Worst case across all three attempts (2s + 5s + 9s of running,
+/// three bursts) is ~190 objects — well short of 300, so the final
+/// attempt still interrupts a busy run. The sibling
+/// `cancel_clean_sigint_does_not_hang` keeps the soft assertion for the
+/// default multi-worker configuration, whose burst behavior has been
+/// observed to outrun the nominal rate.
 #[tokio::test]
 async fn cancel_clean_sigint_mid_deletion_exits_130() {
     let _serial = SIGINT_TEST_LOCK.lock().await;
     let helper = TestHelper::new().await;
     let bucket = generate_bucket_name();
     helper.create_bucket(&bucket, REGION).await;
-    for i in 0..200 {
+    for i in 0..300 {
         helper
             .put_object(&bucket, &format!("k{i:04}"), b"x".to_vec())
             .await;
@@ -397,6 +406,8 @@ async fn cancel_clean_sigint_mid_deletion_exits_130() {
         "--target-region",
         REGION,
         "--force",
+        "--worker-size",
+        "1",
         "--batch-size",
         "10",
         "--rate-limit-objects",

--- a/tests/e2e_ctrl_c.rs
+++ b/tests/e2e_ctrl_c.rs
@@ -97,17 +97,14 @@ async fn run_with_sigint(cmd: &mut std::process::Command) -> Option<i32> {
 // ---- sync ----
 
 #[tokio::test]
-async fn cancel_sync_sigint_does_not_hang() {
+async fn cancel_sync_sigint_exits_130() {
     let _serial = SIGINT_TEST_LOCK.lock().await;
-    // sync's exit-on-SIGINT is non-deterministic: src/sync_bin/cli/mod.rs has
-    // no explicit "cancelled → exit 130" path. Depending on what the pipeline
-    // had done by the time SIGINT lands, the process can exit 0 (clean
-    // cancellation, nothing pending), 3 (warning — partial completion), or
-    // 1 (error). The strict exit-130 assertion that fits cp/mv (which DO
-    // have an explicit ExitStatus::Cancelled path in util_bin) does not
-    // apply to sync. Per the spec's section-7 fallback, we assert only that
-    // the process exits — `run_with_sigint` already enforces a 30s timeout,
-    // so reaching this line proves SIGINT was honored.
+    // src/sync_bin/cli/mod.rs checks `is_ctrl_c_received()` once the
+    // pipeline stops and returns SIGINT_EXIT_CODE (130) regardless of what
+    // the forced shutdown recorded (Ctrl+C takes precedence over errors and
+    // warnings), so the exit code is deterministic: the throttled 30 MiB
+    // transfer guarantees SIGINT lands mid-run, and `run_with_sigint`
+    // retries any attempt where the signal beat the handler installation.
     let helper = TestHelper::new().await;
     let bucket = generate_bucket_name();
     helper.create_bucket(&bucket, REGION).await;
@@ -130,7 +127,8 @@ async fn cancel_sync_sigint_does_not_hang() {
         local_dir.to_str().unwrap(),
     ]);
 
-    let _code = run_with_sigint(&mut cmd).await;
+    let code = run_with_sigint(&mut cmd).await;
+    assert_eq!(code, Some(130), "sync SIGINT must exit 130; got {code:?}");
 
     helper.delete_bucket_with_cascade(&bucket).await;
     let _ = std::fs::remove_dir_all(&local_dir);
@@ -148,9 +146,11 @@ async fn cancel_ls_sigint_does_not_hang() {
     // dispatch-only test, so we fall back to the spec-authorized soft
     // assertion: confirm the process exits (i.e. doesn't hang) and that
     // SIGINT was honored — exact exit code is not required because, on a
-    // very fast listing, the process may complete normally before SIGINT
-    // lands. The richer "must exit 130" assertion is covered by sync, cp,
-    // mv, and clean (which all have per-byte/per-object throttles).
+    // very fast listing, the process may complete normally (exit 0) before
+    // SIGINT lands, while an interrupted run exits 130. The strict
+    // "must exit 130" assertion is covered by
+    // cancel_ls_sigint_mid_paginated_listing_exits_130 below (and by sync,
+    // cp, mv, and clean, which all have per-byte/per-object throttles).
     //
     // `--rate-limit-api` must be >= 10 (its clap range is 10..=u32::MAX);
     // a lower value makes the run die at exit 2 before any S3 call, which
@@ -202,10 +202,11 @@ async fn cancel_clean_sigint_does_not_hang() {
     // throttle is 10/sec with --batch-size 10. With 200 seeded objects the
     // theoretical duration is ~20s, but the leaky-bucket token allowance
     // and concurrent batch deletion mean the first delete can drain the
-    // bucket fast enough that exit 0 races SIGINT — observed in practice.
-    // Per the spec's section-7 fallback, soften to "process exits, doesn't
-    // hang." Strict exit-130 coverage stays in cp/mv (per-byte bandwidth
-    // throttle on a 30 MiB transfer is reliable).
+    // bucket fast enough that exit 0 (normal completion) races SIGINT
+    // (exit 130) — observed in practice. Per the spec's section-7 fallback,
+    // soften to "process exits, doesn't hang." Strict exit-130 coverage
+    // lives in cancel_clean_sigint_mid_deletion_exits_130 below and in
+    // cp/mv (per-byte bandwidth throttle on a 30 MiB transfer is reliable).
     let helper = TestHelper::new().await;
     let bucket = generate_bucket_name();
     helper.create_bucket(&bucket, REGION).await;
@@ -316,8 +317,8 @@ async fn cancel_mv_sigint_exits_130() {
 //
 // The two tests below differ from the "does_not_hang" family above: they
 // shape the workload so SIGINT reliably lands while the operation is still
-// in flight, driving the explicit cancellation returns (ls_bin's
-// "listing cancelled" → 0 and clean_bin's "deletion cancelled" → 0).
+// in flight, driving the explicit cancellation returns (ls_bin's and
+// clean_bin's `is_ctrl_c_received()` → SIGINT_EXIT_CODE, i.e. exit 130).
 //
 // NOTE on flag values: `--rate-limit-api` has a hard floor of 10
 // (`10..=u32::MAX`). A smaller value is a clap error (exit 2) that kills
@@ -329,9 +330,9 @@ async fn cancel_mv_sigint_exits_130() {
 /// ListObjectsV2 calls; `--rate-limit-api 10` (the floor) spaces them
 /// ~10/sec for roughly 15s of listing — comfortably longer than the largest
 /// startup delay in `STARTUP_DELAYS_MS`, so SIGINT always lands mid-listing
-/// and the cancellation branch (exit 0) is taken.
+/// and the cancellation branch (exit 130) is taken.
 #[tokio::test]
-async fn cancel_ls_sigint_mid_paginated_listing_exits_0() {
+async fn cancel_ls_sigint_mid_paginated_listing_exits_130() {
     let _serial = SIGINT_TEST_LOCK.lock().await;
     let helper = TestHelper::new().await;
     let bucket = generate_bucket_name();
@@ -361,8 +362,8 @@ async fn cancel_ls_sigint_mid_paginated_listing_exits_0() {
     let code = run_with_sigint(&mut cmd).await;
     assert_eq!(
         code,
-        Some(0),
-        "cancelled listing must exit 0 (ls cancellation path)"
+        Some(130),
+        "cancelled listing must exit 130 (ls cancellation path)"
     );
 
     helper.delete_bucket_with_cascade(&bucket).await;
@@ -370,12 +371,13 @@ async fn cancel_ls_sigint_mid_paginated_listing_exits_0() {
 
 /// clean over 200 objects with `--batch-size 10 --rate-limit-objects 10`
 /// keeps the deletion pipeline busy for ~20s of theoretical work, so SIGINT
-/// lands mid-run at any delay in `STARTUP_DELAYS_MS` and drives the post-run
-/// "deletion cancelled" branch (exit 0). If the leaky-bucket burst finishes
-/// the bucket first, the run still exits 0 — the assertion is stable either
-/// way; only the covered branch differs.
+/// lands mid-run at any delay in `STARTUP_DELAYS_MS` (at most 9s) and
+/// drives the post-run "deletion cancelled by user" branch (exit 130). A
+/// leaky-bucket burst that drained the bucket before the signal would
+/// surface as exit 0 here — that would mean the throttle window shrank and
+/// the workload needs re-tuning, not that the cancellation path regressed.
 #[tokio::test]
-async fn cancel_clean_sigint_mid_deletion_exits_0() {
+async fn cancel_clean_sigint_mid_deletion_exits_130() {
     let _serial = SIGINT_TEST_LOCK.lock().await;
     let helper = TestHelper::new().await;
     let bucket = generate_bucket_name();
@@ -405,8 +407,8 @@ async fn cancel_clean_sigint_mid_deletion_exits_0() {
     let code = run_with_sigint(&mut cmd).await;
     assert_eq!(
         code,
-        Some(0),
-        "cancelled deletion must exit 0 (clean cancellation path)"
+        Some(130),
+        "cancelled deletion must exit 130 (clean cancellation path)"
     );
 
     helper.delete_bucket_with_cascade(&bucket).await;


### PR DESCRIPTION
## [1.8.0] - 2026-08-07

Bug-fix release, taken as a minor version because the fix changes an observable exit code. No library pins move; the fix lands in s7cmd's vendored command frontends.

**Upgrade notes:**

- [Breaking change] `sync`, `ls`, and `clean` runs interrupted by Ctrl+C (SIGINT) now exit with code `130` instead of `0`. Scripts and automation that test the exit status should treat `130` as user interruption rather than success.

### Fixed

#### sync / ls / clean

- [Breaking change] A run interrupted by Ctrl+C (SIGINT) now exits with code 130 (128 + SIGINT, the conventional shell encoding for termination by signal) instead of 0. Previously an interrupted run was indistinguishable from a successful one by its exit code, and the interruption exit code was inconsistent across subcommands (`cp` and `mv` already exited 130). The Ctrl+C handler records the signal in a process-global flag before cancelling the pipeline, and the frontend checks it once the pipeline has stopped — the interruption takes precedence over whatever the forced shutdown recorded, so in particular a Ctrl+C'd `clean` that had already collected genuine deletion errors no longer exits 0. Uninterrupted runs are unchanged, and so is `clean`'s confirmation prompt, where Ctrl+C still terminates the process immediately through the default OS handler. Ported from nidor1998/s3rm-rs#100 / nidor1998/s3ls-rs#34; the `sync` frontend carries the same fix ahead of upstream s3sync (which has no interruption exit path as of 1.61.2).

#### batch-run

- A Ctrl+C'd `sync`, `ls`, or `clean` line inside a batch is now bucketed `skipped (exit 130)` — matching `cp` and `mv` — where it was previously bucketed `succeeded`. The engines return the interruption code instead of exiting the process, so batch-run itself keeps running exactly as before; the batch exit code follows the existing severity ranking, under which an interrupted batch with no other failures exits 130.

### Testing

- New process-level suite `tests/cli_sigint_exit_code.rs` runs under plain `cargo test` (no AWS access): the real binary is driven against a minimal in-process fake S3 endpoint that keeps the listing/deletion/download pipelines busy until the test delivers SIGINT, covering `ls` (recursive + delimiter), `clean` (dry-run, batch and single-object deletion), `sync` (dry-run + download), and a `batch-run` line, plus no-SIGINT control runs proving the same workloads complete with exit 0.
- Flag-ordering unit tests in each vendored `ctrl_c_handler`; the four ctrl_c_handler test modules now serialize signal delivery through one process-wide lock, and the flag tests assert only straggler-tolerant properties (a SIGINT broadcast can reach handlers spawned by non-lock-holding tests arbitrarily late — validated with 15 consecutive clean full-suite stress runs).
- `tests/e2e_ctrl_c.rs` assertions tightened from "does not hang" to strict exit-130 where the throttled workloads make the outcome deterministic (`sync`, and the mid-listing / mid-deletion `ls` / `clean` tests).

### Underlying libraries

```toml
s3sync = "=1.61.2"
s3util-rs = "=1.9.2"
s3rm-rs = "=1.5.2"
s3ls-rs = "=1.2.2"
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Interrupted `sync`, `ls`, `clean`, `cp`, and `mv` commands now exit with code 130.
  - Ctrl+C takes precedence over previously recorded warnings or errors.
  - `batch-run` now reports interrupted lines as skipped and aggregates interruption results consistently.
  - Added Windows ARM support and release binaries.

- **Documentation**
  - Added guidance on interruption behavior, exit codes, confirmation prompts, and batch results.

- **Chores**
  - Updated the application to version 1.8.0 and refreshed supporting libraries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->