### PR TITLE
update/v1.8.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,43 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.8.1] - 2026-08-08
+
+Bug-fix release. Command-line validation error messages are now always terminated with a newline; previously some
+were printed without one, leaving the next shell prompt on the same line as the error text. The three library pins
+move to the upstream releases of the same fix.
+
+### Fixed
+
+#### sync, ls, clean, cp, mv, rename
+
+- Config-validation error messages (the exit-2 failures raised after clap parsing succeeds, e.g.
+  `error: --recursive is not valid for bucket listing` from `ls -r`, or
+  `error: source S3 URL ending in '/' is not supported: ...` from `cp`) now end with exactly one newline.
+  These messages are printed through `clap::Error::raw`, which writes the message verbatim without appending a
+  newline, so the shell prompt previously landed on the same line as the error. Message texts and exit codes are
+  unchanged; messages that already carried a trailing newline are normalized to a single one.
+
+### Changed
+
+- s3util-rs `v1.10.0 -> v1.10.1`
+- s3rm-rs `v1.6.0 -> v1.6.1`
+- s3ls-rs `v1.3.0 -> v1.3.1`
+
+These are the upstream releases of the same trailing-newline fix for the standalone `s3util`, `s3rm`, and `s3ls`
+binaries. The fixes live in the upstream binary frontends, whose error-printing paths s7cmd replaces with its own
+dispatch layer (fixed here directly), so the pin bumps change no s7cmd behavior on their own. No other
+dependencies were updated.
+
+### Underlying libraries
+
+```toml
+s3sync = "=1.62.0"
+s3util-rs = "=1.10.1"
+s3rm-rs = "=1.6.1"
+s3ls-rs = "=1.3.1"
+```
+
 ## [1.8.0] - 2026-08-08
 
 Bug-fix release, taken as a minor version because the fix changes an observable exit code. All four underlying

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2852,9 +2852,9 @@ checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "s3ls-rs"
-version = "1.3.0"
+version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65721d6f2abda3abb8afcba1c1021633fde91ebb80fadd35f9aee773b4bb58f2"
+checksum = "5552c771cfb186e7cb7add7c80df06bc7bbaeb60acf46ca49083e1adb5c95a02"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2888,9 +2888,9 @@ dependencies = [
 
 [[package]]
 name = "s3rm-rs"
-version = "1.6.0"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3aab909140f3df6cb688e570867ec7134d33adcb66c8a4d4dc535a059aead9b6"
+checksum = "fdc16ff35f12b8355efe537978e51e0d57fc4e08298b0976bad8477cd541c635"
 dependencies = [
  "anyhow",
  "async-channel",
@@ -2992,9 +2992,9 @@ dependencies = [
 
 [[package]]
 name = "s3util-rs"
-version = "1.10.0"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73e25a461d1669c5c0da79366b623c48440aa9d448a993fa5884b7cfcc0aa69d"
+checksum = "bdd682f6787273b722486b5bbb3fd73dcdd3dc40b1b51c05ca2663276e406736"
 dependencies = [
  "anyhow",
  "async-channel",
@@ -3051,7 +3051,7 @@ dependencies = [
 
 [[package]]
 name = "s7cmd"
-version = "1.8.0"
+version = "1.8.1"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "s7cmd"
-version = "1.8.0"
+version = "1.8.1"
 edition = "2024"
 rust-version = "1.94.1"
 license = "Apache-2.0"
@@ -17,10 +17,10 @@ categories = ["command-line-utilities", "filesystem"]
 # (--filter-callback-lua-script, etc.) automatically appear under
 # `s7cmd sync --help`. Use default-features = false to opt out.
 s3sync     = "=1.62.0"
-s3util-rs  = "=1.10.0"
+s3util-rs  = "=1.10.1"
 # Vendored bin code is sourced from these versions; pin minor.
-s3rm-rs    = "=1.6.0"
-s3ls-rs    = "=1.3.0"
+s3rm-rs    = "=1.6.1"
+s3ls-rs    = "=1.3.1"
 
 # Build-info for `s7cmd --version` (gated behind the `version` feature).
 shadow-rs = { version = "2", optional = true, default-features = false }

--- a/src/dispatch.rs
+++ b/src/dispatch.rs
@@ -28,10 +28,7 @@ pub async fn dispatch(cmd: Cmd) -> i32 {
         Cmd::Sync(boxed_args) => {
             let mut config = match s3sync::Config::try_from(*boxed_args) {
                 Ok(c) => c,
-                Err(msg) => {
-                    let _ = clap::Error::raw(clap::error::ErrorKind::ValueValidation, msg).print();
-                    return 2;
-                }
+                Err(msg) => return print_config_error(msg),
             };
             // s3sync's main: when reporting sync status, force dry_run=true.
             if config.report_sync_status {
@@ -61,10 +58,7 @@ pub async fn dispatch(cmd: Cmd) -> i32 {
         Cmd::Ls(boxed_args) => {
             let config = match s3ls_rs::config::Config::try_from(*boxed_args) {
                 Ok(c) => c,
-                Err(msg) => {
-                    let _ = clap::Error::raw(clap::error::ErrorKind::ValueValidation, msg).print();
-                    return 2;
-                }
+                Err(msg) => return print_config_error(msg),
             };
             ls_bin::start_tracing_if_necessary(&config);
             tracing::trace!(target: "s3ls", "config = {:?}", config);
@@ -80,10 +74,7 @@ pub async fn dispatch(cmd: Cmd) -> i32 {
         Cmd::Clean(boxed_args) => {
             let config = match s3rm_rs::config::Config::try_from(*boxed_args) {
                 Ok(c) => c,
-                Err(msg) => {
-                    let _ = clap::Error::raw(clap::error::ErrorKind::ValueValidation, msg).print();
-                    return 2;
-                }
+                Err(msg) => return print_config_error(msg),
             };
             clean_bin::start_tracing_if_necessary(&config);
             tracing::trace!(target: "s3rm", "config = {:?}", config);
@@ -104,10 +95,7 @@ pub async fn dispatch(cmd: Cmd) -> i32 {
         Cmd::Cp(args) => {
             let config = match s3util_rs::Config::try_from(args) {
                 Ok(c) => c,
-                Err(msg) => {
-                    let _ = clap::Error::raw(clap::error::ErrorKind::ValueValidation, msg).print();
-                    return 2;
-                }
+                Err(msg) => return print_config_error(msg),
             };
             start_tracing_if_necessary(&config);
             trace_config_summary(&config);
@@ -123,10 +111,7 @@ pub async fn dispatch(cmd: Cmd) -> i32 {
         Cmd::Mv(args) => {
             let config = match s3util_rs::Config::try_from(args) {
                 Ok(c) => c,
-                Err(msg) => {
-                    let _ = clap::Error::raw(clap::error::ErrorKind::ValueValidation, msg).print();
-                    return 2;
-                }
+                Err(msg) => return print_config_error(msg),
             };
             start_tracing_if_necessary(&config);
             trace_config_summary(&config);
@@ -141,8 +126,7 @@ pub async fn dispatch(cmd: Cmd) -> i32 {
 
         Cmd::Rename(args) => {
             if let Err(e) = args.validate() {
-                let _ = clap::Error::raw(clap::error::ErrorKind::ValueValidation, e).print();
-                return 2;
+                return print_config_error(e);
             }
             let client_config = args.build_client_config();
             match util_bin::cli::run_rename(args, client_config).await {
@@ -438,6 +422,19 @@ pub async fn dispatch(cmd: Cmd) -> i32 {
             status_to_exit(util_bin::cli::run_presign(args, client_config).await)
         }
     }
+}
+
+/// Print a config-validation error to stderr and return exit code 2.
+///
+/// `clap::Error::raw(..).print()` writes the message exactly as given —
+/// unlike clap's formatted errors it appends no trailing newline — so the
+/// shell prompt would otherwise land on the same line as the message.
+/// Upstream messages vary (some already end with `\n`); normalize to
+/// exactly one trailing newline.
+fn print_config_error(msg: impl std::fmt::Display) -> i32 {
+    let msg = format!("{}\n", msg.to_string().trim_end_matches('\n'));
+    let _ = clap::Error::raw(clap::error::ErrorKind::ValueValidation, msg).print();
+    2
 }
 
 // ── Vendored from s3util-rs@1.1.0/src/bin/s3util/main.rs ─────────────

--- a/tests/cli_config_validation_error.rs
+++ b/tests/cli_config_validation_error.rs
@@ -47,17 +47,17 @@ fn both_local_paths_exit_non_zero_with_validation_message_on_stderr() {
     );
 }
 
-#[test]
-fn ls_recursive_without_path_prints_newline_terminated_error() {
-    // Regression guard: `s7cmd ls -r` (bucket listing mode) fails in
-    // s3ls_rs Config::try_from; dispatch prints the message via
-    // clap::Error::raw, which appends no newline on its own. Without the
-    // normalization in `print_config_error` the shell prompt would land
-    // on the same line as the error text.
+/// Run `s7cmd <args>` and assert the config-validation contract shared by
+/// every dispatch arm that routes through `print_config_error`: exit code 2,
+/// the expected message on stderr, and the message terminated by exactly one
+/// newline (clap::Error::raw appends none on its own — without the
+/// normalization in `print_config_error` the shell prompt would land on the
+/// same line as the error text).
+fn assert_validation_error_ends_with_one_newline(args: &[&str], expected_msg: &str) {
     let bin = env!("CARGO_BIN_EXE_s7cmd");
 
     let output = Command::new(bin)
-        .args(["ls", "-r"])
+        .args(args)
         .stdin(Stdio::null())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
@@ -66,16 +66,97 @@ fn ls_recursive_without_path_prints_newline_terminated_error() {
 
     let stderr = String::from_utf8_lossy(&output.stderr);
 
-    assert_eq!(output.status.code(), Some(2));
+    assert_eq!(
+        output.status.code(),
+        Some(2),
+        "s7cmd {args:?} must exit 2 on config validation failure.\n\
+         --- stderr ---\n{stderr}"
+    );
     assert!(
-        stderr.contains("--recursive is not valid for bucket listing"),
-        "expected the recursive-vs-bucket-listing message on stderr.\n\
+        stderr.contains(expected_msg),
+        "expected {expected_msg:?} on stderr for s7cmd {args:?}.\n\
          --- stderr ---\n{stderr}"
     );
     assert!(
         stderr.ends_with('\n') && !stderr.ends_with("\n\n"),
-        "validation message must end with exactly one newline.\n\
-         --- stderr ---\n{stderr:?}"
+        "validation message for s7cmd {args:?} must end with exactly one \
+         newline.\n--- stderr ---\n{stderr:?}"
+    );
+}
+
+// One test per dispatch arm that prints config-validation failures through
+// `print_config_error` (ls, clean, cp, mv, rename, sync). Each drives an
+// invocation that survives clap parsing but fails the library-side config
+// validation, pinning the exit-2 + single-trailing-newline contract.
+
+#[test]
+fn ls_recursive_without_path_prints_newline_terminated_error() {
+    // Bucket-listing mode (no path) rejects --recursive in
+    // s3ls_rs Config::try_from.
+    assert_validation_error_ends_with_one_newline(
+        &["ls", "-r"],
+        "--recursive is not valid for bucket listing",
+    );
+}
+
+#[test]
+fn clean_rate_limit_below_batch_size_prints_newline_terminated_error() {
+    // s3rm_rs Config::try_from rejects --rate-limit-objects below the
+    // batch size (default 200).
+    assert_validation_error_ends_with_one_newline(
+        &["clean", "--rate-limit-objects", "100", "s3://bucket"],
+        "must be greater than or equal to --batch-size",
+    );
+}
+
+#[test]
+fn cp_source_url_with_trailing_slash_prints_newline_terminated_error() {
+    // The trailing-'/' source message is one of the s3util-rs validation
+    // strings without a hand-embedded '\n' (fixed bin-side upstream in
+    // s3util-rs 1.10.1; s7cmd normalizes in print_config_error).
+    assert_validation_error_ends_with_one_newline(
+        &["cp", "s3://bucket/dir/", "/tmp/"],
+        "object, not a prefix",
+    );
+}
+
+#[test]
+fn mv_source_url_with_trailing_slash_prints_newline_terminated_error() {
+    assert_validation_error_ends_with_one_newline(
+        &["mv", "s3://bucket/dir/", "/tmp/"],
+        "object, not a prefix",
+    );
+}
+
+#[test]
+fn rename_on_general_purpose_bucket_prints_newline_terminated_error() {
+    // rename requires an S3 Express One Zone bucket; args.validate()
+    // rejects a general-purpose bucket name.
+    assert_validation_error_ends_with_one_newline(
+        &["rename", "s3://bucket/a", "s3://bucket/b"],
+        "only supported on S3 Express One Zone buckets",
+    );
+}
+
+#[test]
+fn sync_missing_local_source_prints_newline_terminated_error() {
+    // A nonexistent local source fails s3sync Config::try_from before
+    // any S3 call.
+    let missing_src = std::env::temp_dir().join(format!(
+        "s7cmd_validation_missing_src_{}",
+        uuid::Uuid::new_v4()
+    ));
+    let missing_dst = std::env::temp_dir().join(format!(
+        "s7cmd_validation_missing_dst_{}",
+        uuid::Uuid::new_v4()
+    ));
+    assert_validation_error_ends_with_one_newline(
+        &[
+            "sync",
+            missing_src.to_str().unwrap(),
+            missing_dst.to_str().unwrap(),
+        ],
+        "source file/directory not found",
     );
 }
 

--- a/tests/cli_config_validation_error.rs
+++ b/tests/cli_config_validation_error.rs
@@ -39,6 +39,44 @@ fn both_local_paths_exit_non_zero_with_validation_message_on_stderr() {
         "expected the check_both_local validation message on stderr.\n\
          --- stderr ---\n{stderr}"
     );
+
+    assert!(
+        stderr.ends_with('\n'),
+        "validation message must end with a newline so the shell prompt \
+         starts on its own line.\n--- stderr ---\n{stderr:?}"
+    );
+}
+
+#[test]
+fn ls_recursive_without_path_prints_newline_terminated_error() {
+    // Regression guard: `s7cmd ls -r` (bucket listing mode) fails in
+    // s3ls_rs Config::try_from; dispatch prints the message via
+    // clap::Error::raw, which appends no newline on its own. Without the
+    // normalization in `print_config_error` the shell prompt would land
+    // on the same line as the error text.
+    let bin = env!("CARGO_BIN_EXE_s7cmd");
+
+    let output = Command::new(bin)
+        .args(["ls", "-r"])
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()
+        .expect("failed to spawn s7cmd binary");
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert_eq!(output.status.code(), Some(2));
+    assert!(
+        stderr.contains("--recursive is not valid for bucket listing"),
+        "expected the recursive-vs-bucket-listing message on stderr.\n\
+         --- stderr ---\n{stderr}"
+    );
+    assert!(
+        stderr.ends_with('\n') && !stderr.ends_with("\n\n"),
+        "validation message must end with exactly one newline.\n\
+         --- stderr ---\n{stderr:?}"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## [1.8.1] - 2026-08-08

Bug-fix release. Command-line validation error messages are now always terminated with a newline; previously some
were printed without one, leaving the next shell prompt on the same line as the error text. The three library pins
move to the upstream releases of the same fix.

### Fixed

#### sync, ls, clean, cp, mv, rename

- Config-validation error messages (the exit-2 failures raised after clap parsing succeeds, e.g.
  `error: --recursive is not valid for bucket listing` from `ls -r`, or
  `error: source S3 URL ending in '/' is not supported: ...` from `cp`) now end with exactly one newline.
  These messages are printed through `clap::Error::raw`, which writes the message verbatim without appending a
  newline, so the shell prompt previously landed on the same line as the error. Message texts and exit codes are
  unchanged; messages that already carried a trailing newline are normalized to a single one.

### Changed

- s3util-rs `v1.10.0 -> v1.10.1`
- s3rm-rs `v1.6.0 -> v1.6.1`
- s3ls-rs `v1.3.0 -> v1.3.1`

These are the upstream releases of the same trailing-newline fix for the standalone `s3util`, `s3rm`, and `s3ls`
binaries. The fixes live in the upstream binary frontends, whose error-printing paths s7cmd replaces with its own
dispatch layer (fixed here directly), so the pin bumps change no s7cmd behavior on their own. No other
dependencies were updated.

### Underlying libraries

```toml
s3sync = "=1.62.0"
s3util-rs = "=1.10.1"
s3rm-rs = "=1.6.1"
s3ls-rs = "=1.3.1"
```

---

This PR contains two commits: the dispatch-layer newline fix (`fix(dispatch): terminate config-validation errors with a newline`, branched from `fix/no_new_line`) and the release prep (pin roll, version bump, changelog, regression tests for all six validation arms).

Verified locally: `cargo fmt --check`, `cargo clippy --all-features`, `cargo clippy -- -D warnings`, `cargo deny -L error check`, and the full non-e2e suite all pass; e2e-gated code compiles cleanly under `RUSTFLAGS="--cfg e2e_test"`. The e2e suite has not been run — please run `RUSTFLAGS="--cfg e2e_test" cargo test --all-features --no-fail-fast` before merging/tagging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Standardized CLI validation errors to include exactly one trailing newline.
  * Ensured configuration and argument validation failures consistently return exit code 2 across supported commands.

* **Documentation**
  * Added the 1.8.1 changelog entry documenting the CLI error formatting improvements.

* **Maintenance**
  * Updated the application and related command-line tool versions to releases containing these fixes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->